### PR TITLE
fix: three tier-1 plot/visibility bugs (closes #46, #47, #48)

### DIFF
--- a/src/CastleOverlayV2/MainForm.cs
+++ b/src/CastleOverlayV2/MainForm.cs
@@ -839,21 +839,17 @@ namespace CastleOverlayV2
         }
 
         /// <summary>
-        /// ✅ Toggle changed — update plot and persist to config
+        /// Toggle changed — update plot visibility surgically and persist to config.
         /// </summary>
         private void OnChannelVisibilityChanged(string channelName, bool isVisible)
         {
             Logger.Log($"📎 Channel toggle clicked: {channelName} → {(isVisible ? "Show" : "Hide")}");
 
+            // Fix #48: SetChannelVisibility already updates per-scatter IsVisible and refreshes.
+            // The previous full PlotAllRuns() call here was redundant double work.
             _plotManager.SetChannelVisibility(channelName, isVisible);
-            _plotManager.RefreshPlot();
 
-            // ✅ Save updated state immediately
             _configService.SetChannelVisibility(channelName, isVisible);
-
-            // 🔄 Force full replot to ensure sync
-            Logger.Log("🔄 Forcing full replot after channel toggle");
-            PlotAllRuns();
         }
 
         /// <summary>
@@ -989,15 +985,10 @@ namespace CastleOverlayV2
             _isFourPoleMode = isFourPole;
             _plotManager.SetFourPoleMode(_isFourPoleMode);
 
-            var runsToPlot = new Dictionary<int, RunData>();
-            if (run1 != null) runsToPlot[1] = run1;
-            if (run2 != null) run2.TimeShiftMs += 0; // keep compiler happy if stripped warnings; no-op
-            if (run2 != null) runsToPlot[2] = run2;
-            if (run3 != null) runsToPlot[3] = run3;
+            // Fix #46: replot ALL runs (Castle + RaceBox), not just slots 1–3.
+            PlotAllRuns();
 
-            _plotManager.PlotRuns(runsToPlot);
-
-            _configService.SetRpmMode(isFourPole); // ✅ persist to config.json
+            _configService.SetRpmMode(isFourPole);
         }
 
         private void LogClick(string buttonName)

--- a/src/CastleOverlayV2/Plot/PlotManager.cs
+++ b/src/CastleOverlayV2/Plot/PlotManager.cs
@@ -665,14 +665,12 @@ namespace CastleOverlayV2.Plot
                     continue;
 
                 var rbTyped = pts.OfType<ModelPoint>().ToList();
-                if (rbTyped.Count == 0) continue;
+                if (rbTyped.Count < 2) continue;
 
-                var good = rbTyped.Where(p => Math.Abs(p.Y) > 0.01).ToList();
-                if (good.Count < 2) continue;
-
+                // Fix #47: plot all samples, including legitimate near-zero G-Force values.
                 double shiftSec = run.TimeShiftMs / 1000.0;
-                double[] xs = good.Select(p => p.Time + shiftSec).ToArray();
-                double[] ys = good.Select(p => p.Y).ToArray();
+                double[] xs = rbTyped.Select(p => p.Time + shiftSec).ToArray();
+                double[] ys = rbTyped.Select(p => p.Y).ToArray();
 
                 var s = _plot.Plot.Add.Scatter(xs, ys);
                 s.Label = ch;


### PR DESCRIPTION
## Summary
Three small user-visible bug fixes bundled together — each is a few lines and they all touch plot/visibility behavior.

- **Closes #46** — `OnRpmModeChanged` was rebuilding a partial dict with only Castle slots 1–3 and calling `PlotRuns`, which dropped RaceBox overlays. Now uses `PlotAllRuns()` which collects all 6 slots. Also removed the stale `run2.TimeShiftMs += 0` no-op.
- **Closes #47** — `PlotRaceBoxRun` was filtering out RaceBox samples where \`|Y| <= 0.01\`, creating visible gaps in the G-Force trace at every zero crossing. Filter removed; the \`Count < 2\` guard now runs on the full sample set.
- **Closes #48** — `OnChannelVisibilityChanged` was doing the surgical \`SetChannelVisibility\` + `RefreshPlot` AND then a full `PlotAllRuns()` rebuild. Dropped the redundant full replot; the surgical path correctly flips per-scatter visibility.

## Build
\`dotnet build -c Release\` clean — 0 errors. (The 93 warnings are pre-existing ScottPlot v5 deprecation notices and nullable-ref warnings in `CsvLoader` / `MainForm`; none introduced by this PR.)

## Test plan
- [ ] Load Castle Run 1, Run 2, and at least one RaceBox slot.
- [ ] Toggle 2P ↔ 4P. RaceBox overlays must remain on the chart after each toggle (#46).
- [ ] Visually inspect G-Force X trace near zero crossings — should be continuous, no dropout (#47).
- [ ] Toggle a channel on the bottom bar a few times. Plot should react instantly (no double redraw flicker), and channel state should persist in config.json after restart (#48).

## Workflow
Per repo `CLAUDE.md`: this PR is yours to merge — I will not run `gh pr merge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)