### PR TITLE
chore: add xUnit test project covering pure utilities (closes #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ It overlays up to 3 Castle logs, optionally syncs RaceBox GPS data, and plots ev
 4. Build in **Release mode**
 5. Run the generated `.exe` from `bin\Release\net8.0-windows\`
 
+### Run tests
+
+```powershell
+dotnet test Tests/CastleOverlayV2.Tests/CastleOverlayV2.Tests.csproj
+```
+
 ---
 
 ## 💾 Config System

--- a/Tests/CastleOverlayV2.Tests/CastleOverlayV2.Tests.csproj
+++ b/Tests/CastleOverlayV2.Tests/CastleOverlayV2.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\CastleOverlayV2\CastleOverlayV2.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/CastleOverlayV2.Tests/LineStyleHelperTests.cs
+++ b/Tests/CastleOverlayV2.Tests/LineStyleHelperTests.cs
@@ -1,0 +1,54 @@
+using CastleOverlayV2.Utils;
+using ScottPlot;
+
+namespace CastleOverlayV2.Tests;
+
+public class LineStyleHelperTests
+{
+    [Theory]
+    [InlineData(0, 2.5)] // Castle Run 1 — boldest
+    [InlineData(1, 1.5)] // Castle Run 2
+    [InlineData(2, 1.0)] // Castle Run 3 — thinnest
+    [InlineData(3, 2.0)] // RaceBox 1 — default
+    [InlineData(4, 2.0)] // RaceBox 2 — default
+    [InlineData(5, 2.0)] // RaceBox 3 — default
+    [InlineData(99, 2.0)] // Split lines — default
+    [InlineData(-1, 2.0)] // Out of range — default
+    public void GetLineWidth_returns_expected(int index, double expected)
+    {
+        Assert.Equal(expected, LineStyleHelper.GetLineWidth(index));
+    }
+
+    [Theory]
+    [InlineData(0, "Solid")]  // Castle Run 1
+    [InlineData(3, "Solid")]  // RaceBox 1 (paired with Run 1)
+    [InlineData(1, "Dashed")] // Castle Run 2
+    [InlineData(4, "Dashed")] // RaceBox 2 (paired with Run 2)
+    [InlineData(2, "Dotted")] // Castle Run 3
+    [InlineData(5, "Dotted")] // RaceBox 3 (paired with Run 3)
+    [InlineData(99, "Dashed")] // Split lines marker
+    [InlineData(-1, "Solid")]  // Out of range — default
+    [InlineData(7, "Solid")]   // Out of range — default
+    public void GetLinePattern_returns_expected(int index, string expectedName)
+    {
+        var expected = expectedName switch
+        {
+            "Solid" => LinePattern.Solid,
+            "Dashed" => LinePattern.Dashed,
+            "Dotted" => LinePattern.Dotted,
+            _ => throw new System.ArgumentException($"unknown pattern: {expectedName}")
+        };
+
+        Assert.Equal(expected, LineStyleHelper.GetLinePattern(index));
+    }
+
+    [Fact]
+    public void Castle_and_RaceBox_pairs_share_LinePattern()
+    {
+        // The slot-pairing convention (Castle slot N ↔ RaceBox slot N+3) requires
+        // matched line patterns so a Castle/RaceBox overlay reads as one run.
+        Assert.Equal(LineStyleHelper.GetLinePattern(0), LineStyleHelper.GetLinePattern(3));
+        Assert.Equal(LineStyleHelper.GetLinePattern(1), LineStyleHelper.GetLinePattern(4));
+        Assert.Equal(LineStyleHelper.GetLinePattern(2), LineStyleHelper.GetLinePattern(5));
+    }
+}

--- a/Tests/CastleOverlayV2.Tests/ThrottlePercentTests.cs
+++ b/Tests/CastleOverlayV2.Tests/ThrottlePercentTests.cs
@@ -1,0 +1,80 @@
+using CastleOverlayV2.Services;
+
+namespace CastleOverlayV2.Tests;
+
+public class ThrottlePercentTests
+{
+    // Castle radio defaults (matches CsvLoader.cs).
+    private const double FullReverse = 1.048;
+    private const double Neutral = 1.500;
+    private const double FullForward = 1.910;
+
+    [Fact]
+    public void Neutral_returns_zero()
+    {
+        Assert.Equal(0, ThrottlePercent.FromMilliseconds(Neutral, FullReverse, Neutral, FullForward));
+    }
+
+    [Fact]
+    public void FullForward_returns_plus_100()
+    {
+        Assert.Equal(100, ThrottlePercent.FromMilliseconds(FullForward, FullReverse, Neutral, FullForward));
+    }
+
+    [Fact]
+    public void FullReverse_returns_minus_100()
+    {
+        Assert.Equal(-100, ThrottlePercent.FromMilliseconds(FullReverse, FullReverse, Neutral, FullForward));
+    }
+
+    [Fact]
+    public void Halfway_forward_returns_plus_50()
+    {
+        double halfway = Neutral + (FullForward - Neutral) / 2.0;
+        Assert.Equal(50, ThrottlePercent.FromMilliseconds(halfway, FullReverse, Neutral, FullForward), precision: 6);
+    }
+
+    [Fact]
+    public void Halfway_reverse_returns_minus_50()
+    {
+        double halfway = Neutral - (Neutral - FullReverse) / 2.0;
+        Assert.Equal(-50, ThrottlePercent.FromMilliseconds(halfway, FullReverse, Neutral, FullForward), precision: 6);
+    }
+
+    [Fact]
+    public void Above_full_forward_clamps_to_100()
+    {
+        Assert.Equal(100, ThrottlePercent.FromMilliseconds(FullForward + 0.5, FullReverse, Neutral, FullForward));
+    }
+
+    [Fact]
+    public void Below_full_reverse_clamps_to_minus_100()
+    {
+        Assert.Equal(-100, ThrottlePercent.FromMilliseconds(FullReverse - 0.5, FullReverse, Neutral, FullForward));
+    }
+
+    [Fact]
+    public void Inverted_cal_returns_zero()
+    {
+        // Neutral outside [min, max] → guard rail: return 0
+        Assert.Equal(0, ThrottlePercent.FromMilliseconds(1.7, 1.5, 1.0, 1.9));
+    }
+
+    [Fact]
+    public void Zero_forward_span_returns_zero_at_neutral_or_above()
+    {
+        // neutralMs == fullForwardMs collapses forward span.
+        // Below-neutral path still works; at/above-neutral path must guard.
+        double pct = ThrottlePercent.FromMilliseconds(1.6, 1.0, 1.5, 1.5);
+        Assert.Equal(0, pct);
+    }
+
+    [Fact]
+    public void Zero_reverse_span_returns_zero_below_neutral()
+    {
+        // neutralMs == fullReverseMs collapses reverse span.
+        // Above-neutral path still works; below-neutral path must guard.
+        double pct = ThrottlePercent.FromMilliseconds(1.4, 1.5, 1.5, 2.0);
+        Assert.Equal(0, pct);
+    }
+}

--- a/src/CastleOverlayV2/CastleOverlayV2.sln
+++ b/src/CastleOverlayV2/CastleOverlayV2.sln
@@ -1,20 +1,46 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.14.36121.58 d17.14
+VisualStudioVersion = 17.14.36121.58
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CastleOverlayV2", "CastleOverlayV2.csproj", "{05C5FBB5-3F51-904D-7AA1-049B7FA00091}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CastleOverlayV2.Tests", "..\..\Tests\CastleOverlayV2.Tests\CastleOverlayV2.Tests.csproj", "{8C95EB3E-D16D-4683-8744-7A904DF516FD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{05C5FBB5-3F51-904D-7AA1-049B7FA00091}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{05C5FBB5-3F51-904D-7AA1-049B7FA00091}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{05C5FBB5-3F51-904D-7AA1-049B7FA00091}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{05C5FBB5-3F51-904D-7AA1-049B7FA00091}.Debug|x64.Build.0 = Debug|Any CPU
+		{05C5FBB5-3F51-904D-7AA1-049B7FA00091}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{05C5FBB5-3F51-904D-7AA1-049B7FA00091}.Debug|x86.Build.0 = Debug|Any CPU
 		{05C5FBB5-3F51-904D-7AA1-049B7FA00091}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{05C5FBB5-3F51-904D-7AA1-049B7FA00091}.Release|Any CPU.Build.0 = Release|Any CPU
+		{05C5FBB5-3F51-904D-7AA1-049B7FA00091}.Release|x64.ActiveCfg = Release|Any CPU
+		{05C5FBB5-3F51-904D-7AA1-049B7FA00091}.Release|x64.Build.0 = Release|Any CPU
+		{05C5FBB5-3F51-904D-7AA1-049B7FA00091}.Release|x86.ActiveCfg = Release|Any CPU
+		{05C5FBB5-3F51-904D-7AA1-049B7FA00091}.Release|x86.Build.0 = Release|Any CPU
+		{8C95EB3E-D16D-4683-8744-7A904DF516FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C95EB3E-D16D-4683-8744-7A904DF516FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8C95EB3E-D16D-4683-8744-7A904DF516FD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8C95EB3E-D16D-4683-8744-7A904DF516FD}.Debug|x64.Build.0 = Debug|Any CPU
+		{8C95EB3E-D16D-4683-8744-7A904DF516FD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8C95EB3E-D16D-4683-8744-7A904DF516FD}.Debug|x86.Build.0 = Debug|Any CPU
+		{8C95EB3E-D16D-4683-8744-7A904DF516FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8C95EB3E-D16D-4683-8744-7A904DF516FD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8C95EB3E-D16D-4683-8744-7A904DF516FD}.Release|x64.ActiveCfg = Release|Any CPU
+		{8C95EB3E-D16D-4683-8744-7A904DF516FD}.Release|x64.Build.0 = Release|Any CPU
+		{8C95EB3E-D16D-4683-8744-7A904DF516FD}.Release|x86.ActiveCfg = Release|Any CPU
+		{8C95EB3E-D16D-4683-8744-7A904DF516FD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
Closes #55. Adds the first automated test project.

- New project: `Tests/CastleOverlayV2.Tests/` targeting `net8.0-windows` (matches main project so it can reference `CastleOverlayV2.csproj`).
- 28 tests, all passing.
- README updated with the test command.
- Test project added to `CastleOverlayV2.sln`.

## Coverage
- `ThrottlePercentTests` (10 tests) — neutral, full forward, full reverse, halfway forward/reverse, clamping above/below endpoints, inverted cal, zero forward span, zero reverse span.
- `LineStyleHelperTests` (18 tests) — `GetLineWidth` and `GetLinePattern` for all valid slot indices, out-of-range defaults, plus an invariant test that Castle slot N and RaceBox slot N+3 share a line pattern (load-bearing for the visual pairing).

## Why this matters
- Locks in throttle-percent behavior **before** #52 unifies the two duplicate implementations (`ThrottlePercent.FromMilliseconds` vs `CsvLoader.MsToPercent`).
- Establishes the harness for future tests as more logic moves out of `MainForm` (#57).

## Run
```powershell
dotnet test Tests/CastleOverlayV2.Tests/CastleOverlayV2.Tests.csproj
```

```
Passed!  - Failed: 0, Passed: 28, Skipped: 0, Total: 28, Duration: 1 s
```

## Test plan
- [ ] `dotnet test Tests/CastleOverlayV2.Tests/CastleOverlayV2.Tests.csproj` — all 28 pass.
- [ ] Solution still builds in Visual Studio.
- [ ] Main app build unchanged.

## Workflow
Per repo `CLAUDE.md`: yours to merge — I will not run `gh pr merge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)