### PR TITLE
chore: unify throttle-to-percent on ThrottlePercent.FromMilliseconds (closes #52)

### DIFF
--- a/src/CastleOverlayV2/Services/CsvLoader.cs
+++ b/src/CastleOverlayV2/Services/CsvLoader.cs
@@ -174,7 +174,8 @@ namespace CastleOverlayV2.Services
                         }
 
                         double throttleMs = GetDouble("Throttle");
-                        double throttlePct = MsToPercent(throttleMs, cal);
+                        double throttlePct = ThrottlePercent.FromMilliseconds(
+                            throttleMs, cal.MinMs, cal.NeutralMs, cal.MaxMs);
 
                         var point = new DataPoint
                         {
@@ -263,29 +264,6 @@ namespace CastleOverlayV2.Services
             public double MinMs;
             public double NeutralMs;
             public double MaxMs;
-        }
-
-        private static double MsToPercent(double ms, ThrottleCal cal)
-        {
-            double min = Math.Min(cal.MinMs, cal.MaxMs);
-            double max = Math.Max(cal.MinMs, cal.MaxMs);
-            double neu = cal.NeutralMs;
-
-            if (!(min < neu && neu < max))
-                return 0.0;
-
-            if (ms >= neu)
-            {
-                double span = Math.Max(1e-9, max - neu);
-                double pct = (ms - neu) / span * 100.0;
-                return Math.Min(100.0, Math.Max(0.0, pct));
-            }
-            else
-            {
-                double span = Math.Max(1e-9, neu - min);
-                double pct = -(neu - ms) / span * 100.0;
-                return Math.Max(-100.0, Math.Min(0.0, pct));
-            }
         }
 
         private static int DetectDragStartIndex(List<DataPoint> data)


### PR DESCRIPTION
## Summary
Closes #52. The clean public `ThrottlePercent.FromMilliseconds` now actually runs; the private duplicate in `CsvLoader.MsToPercent` is gone.

## Diff
1 file changed, +2 / -24.

`CsvLoader.cs` now calls:
\`\`\`csharp
double throttlePct = ThrottlePercent.FromMilliseconds(
    throttleMs, cal.MinMs, cal.NeutralMs, cal.MaxMs);
\`\`\`

## Behaviour equivalence
For any real Castle radio cal (`min < neutral < max`), the two implementations produce identical output. I checked the edge cases:

| Input region | MsToPercent | FromMilliseconds | Same? |
|---|---|---|---|
| Above neutral, in range | `[0..100]` clamp | `[-100..100]` clamp on positive value | ✅ |
| Below neutral, in range | `[-100..0]` clamp | `[-100..100]` clamp on negative value | ✅ |
| Above `max` | clamped to 100 | clamped to 100 | ✅ |
| Below `min` | clamped to -100 | clamped to -100 | ✅ |
| Inverted cal (`min > max`) | self-corrects via Min/Max sort | rejects → returns 0 | ⚠️ differs |

Inverted cal can't happen with real ESC firmware (the CSV header writes `Full Reverse: X` < `Full Forward: Y`), so the divergence is theoretical.

## Tests
The test suite added in #60 (10 `ThrottlePercent` tests + 18 `LineStyleHelper` tests) all pass after the swap.

\`\`\`
Passed!  - Failed: 0, Passed: 28, Skipped: 0, Total: 28
\`\`\`

## Test plan
- [ ] `dotnet test Tests/CastleOverlayV2.Tests/CastleOverlayV2.Tests.csproj` — 28/28.
- [ ] Load a real Castle CSV in the app. Throttle channel should plot identically to before this change.

## Workflow
Per repo `CLAUDE.md`: yours to merge — I will not run `gh pr merge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)