### PR TITLE
perf: cache channel→scatters lookup for hover (closes #50)

### DIFF
--- a/src/CastleOverlayV2/Plot/PlotManager.cs
+++ b/src/CastleOverlayV2/Plot/PlotManager.cs
@@ -33,6 +33,9 @@ namespace CastleOverlayV2.Plot
         private readonly Dictionary<Scatter, double[]> _rawYMap = new();
         private readonly Dictionary<Scatter, int> _scatterSlotMap = new();
 
+        // Lazy cache of channel → scatters, rebuilt on demand after _scatters mutates.
+        private Dictionary<string, List<Scatter>>? _channelToScattersCache;
+
         // Visibility & storage
         private readonly Dictionary<int, bool> _runVisibility = new();
         private Dictionary<string, bool> _channelVisibility = new();
@@ -250,6 +253,8 @@ namespace CastleOverlayV2.Plot
                     _scatterSlotMap.Remove(s);
                     _rawYMap.Remove(s);
                 }
+                if (toRemove.Count > 0)
+                    _channelToScattersCache = null;
 
                 if (_splitLinesBySlot.TryGetValue(slot, out var lines))
                 {
@@ -286,6 +291,7 @@ namespace CastleOverlayV2.Plot
             _scatters.Clear();
             _rawYMap.Clear();
             _scatterSlotMap.Clear();
+            _channelToScattersCache = null;
             _plot.Plot.Axes.Rules.Clear();
             _splitLabelAxis = null;
 
@@ -736,6 +742,27 @@ namespace CastleOverlayV2.Plot
 
         // ---------------- Hover ----------------
 
+        // Channel-name → scatters lookup used by MouseMove. Rebuilt lazily after any
+        // mutation of _scatters (PlotRuns reset, SetRun slot-removal).
+        private Dictionary<string, List<Scatter>> GetChannelToScatters()
+        {
+            if (_channelToScattersCache is not null)
+                return _channelToScattersCache;
+
+            var cache = new Dictionary<string, List<Scatter>>();
+            foreach (var s in _scatters)
+            {
+                if (!cache.TryGetValue(s.Label, out var list))
+                {
+                    list = new List<Scatter>();
+                    cache[s.Label] = list;
+                }
+                list.Add(s);
+            }
+            _channelToScattersCache = cache;
+            return cache;
+        }
+
         private void FormsPlot_MouseMove(object sender, MouseEventArgs e)
         {
             if (_cursor == null) return;
@@ -745,9 +772,7 @@ namespace CastleOverlayV2.Plot
 
             var valuesAtCursor = new Dictionary<string, double?[]>();
 
-            var channels = _scatters
-                .GroupBy(s => s.Label)
-                .ToDictionary(g => g.Key, g => g.ToList());
+            var channels = GetChannelToScatters();
 
             foreach (var kvp in channels)
             {


### PR DESCRIPTION
## Summary
Closes #50. The hover handler now amortises its channel-grouping work instead of rebuilding it every pixel.

## Diff
1 file changed, +28 / -3.

## What changed
- New private field `_channelToScattersCache` next to `_scatters`.
- `FormsPlot_MouseMove` reads from `GetChannelToScatters()` instead of doing `_scatters.GroupBy(...).ToDictionary(...)` per event.
- Cache is invalidated (set to `null`) at the only two places `_scatters` mutates:
  - `PlotRuns` after `_scatters.Clear()` (start of every replot).
  - `SetRun(slot, null)` after the per-slot scatter-removal loop, only if something was actually removed.
- Cache rebuilds lazily on the next hover.

## Why it's safe
- `_scatters` only mutates from the UI thread (PlotRuns / SetRun); `MouseMove` also runs on the UI thread, so no interleaving. The cache can only be observed in a consistent state.
- Adds in `PlotRuns` happen inside the same UI-thread call as the preceding `_channelToScattersCache = null`, so when MouseMove fires later it rebuilds with everything in place.
- Final lookup behavior is unchanged.

## Tests
\`\`\`
Passed!  - Failed: 0, Passed: 28, Skipped: 0, Total: 28
\`\`\`

## Test plan
- [ ] Load 1, 2, then 3 Castle runs. Hover values appear correctly under each channel.
- [ ] Add a RaceBox slot. Hover values for `RaceBox Speed` and `RaceBox G-Force X` appear correctly.
- [ ] Toggle a channel off, hover — value goes to `—`. Toggle back on, hover — value reappears.
- [ ] Delete a run — hover values for that run disappear; remaining runs still report correctly.
- [ ] No visible lag while moving the mouse fast across the chart.

## Workflow
Per repo `CLAUDE.md`: yours to merge — I will not run `gh pr merge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)