### PR TITLE
perf: gate hot-path Logger calls behind IsEnabled (closes #51)

### DIFF
--- a/src/CastleOverlayV2/MainForm.cs
+++ b/src/CastleOverlayV2/MainForm.cs
@@ -713,13 +713,16 @@ namespace CastleOverlayV2
         /// </summary>
         private void PlotAllRuns()
         {
-            Logger.Log("PlotAllRuns called with runs:");
-            if (run1 != null) Logger.Log($"  Run 1: {run1.DataPoints.Count} points, shift={run1.TimeShiftMs} ms");
-            if (run2 != null) Logger.Log($"  Run 2: {run2.DataPoints.Count} points, shift={run2.TimeShiftMs} ms");
-            if (run3 != null) Logger.Log($"  Run 3: {run3.DataPoints.Count} points, shift={run3.TimeShiftMs} ms");
-            if (run4 != null) Logger.Log($"  Run 4: {run4.DataPoints.Count} points, shift={run4.TimeShiftMs} ms");
-            if (run5 != null) Logger.Log($"  Run 5: {run5.DataPoints.Count} points, shift={run5.TimeShiftMs} ms");
-            if (run6 != null) Logger.Log($"  Run 6: {run6.DataPoints.Count} points, shift={run6.TimeShiftMs} ms");
+            if (Logger.IsEnabled)
+            {
+                Logger.Log("PlotAllRuns called with runs:");
+                if (run1 != null) Logger.Log($"  Run 1: {run1.DataPoints.Count} points, shift={run1.TimeShiftMs} ms");
+                if (run2 != null) Logger.Log($"  Run 2: {run2.DataPoints.Count} points, shift={run2.TimeShiftMs} ms");
+                if (run3 != null) Logger.Log($"  Run 3: {run3.DataPoints.Count} points, shift={run3.TimeShiftMs} ms");
+                if (run4 != null) Logger.Log($"  Run 4: {run4.DataPoints.Count} points, shift={run4.TimeShiftMs} ms");
+                if (run5 != null) Logger.Log($"  Run 5: {run5.DataPoints.Count} points, shift={run5.TimeShiftMs} ms");
+                if (run6 != null) Logger.Log($"  Run 6: {run6.DataPoints.Count} points, shift={run6.TimeShiftMs} ms");
+            }
 
             var runsToPlot = new Dictionary<int, RunData>();
             if (run1 != null) runsToPlot[1] = run1;
@@ -732,9 +735,12 @@ namespace CastleOverlayV2
 
             var visibilityMap = _channelToggleBar.GetChannelStates();
 
-            Logger.Log("PlotAllRuns — Channel visibility map before applying:");
-            foreach (var kvp in visibilityMap)
-                Logger.Log($"  Channel: {kvp.Key}, Visible: {kvp.Value}");
+            if (Logger.IsEnabled)
+            {
+                Logger.Log("PlotAllRuns — Channel visibility map before applying:");
+                foreach (var kvp in visibilityMap)
+                    Logger.Log($"  Channel: {kvp.Key}, Visible: {kvp.Value}");
+            }
 
             _plotManager.SetInitialChannelVisibility(visibilityMap);
             _plotManager.PlotRuns(runsToPlot);

--- a/src/CastleOverlayV2/Plot/PlotManager.cs
+++ b/src/CastleOverlayV2/Plot/PlotManager.cs
@@ -219,9 +219,12 @@ namespace CastleOverlayV2.Plot
 
         public void SetInitialChannelVisibility(Dictionary<string, bool> visibilityMap)
         {
-            Logger.Log("🟢 SetInitialChannelVisibility():");
-            foreach (var kvp in visibilityMap)
-                Logger.Log($"   • {kvp.Key} = {(kvp.Value ? "Visible" : "Hidden")}");
+            if (Logger.IsEnabled)
+            {
+                Logger.Log("🟢 SetInitialChannelVisibility():");
+                foreach (var kvp in visibilityMap)
+                    Logger.Log($"   • {kvp.Key} = {(kvp.Value ? "Visible" : "Hidden")}");
+            }
             _channelVisibility = visibilityMap ?? new();
         }
 
@@ -879,6 +882,8 @@ namespace CastleOverlayV2.Plot
 
         public void LogVisibilityStates()
         {
+            if (!Logger.IsEnabled) return;
+
             Logger.Log("🔍 Current Run Visibility States:");
             foreach (var kvp in _runVisibility)
                 Logger.Log($"   Run Slot {kvp.Key}: {(kvp.Value ? "Visible" : "Hidden")}");

--- a/src/CastleOverlayV2/Services/CsvLoader.cs
+++ b/src/CastleOverlayV2/Services/CsvLoader.cs
@@ -195,7 +195,8 @@ namespace CastleOverlayV2.Services
 
                         log?.WriteLine($"Row {rowIndex}: Throttle(ms)={throttleMs:F4}  Throttle(%)={throttlePct:F1}");
                         runData.DataPoints.Add(point);
-                        Logger.Log($"Row {rowIndex}: ADDED — Time={point.Time:F2} Acceleration={point.Acceleration}");
+                        if (Logger.IsEnabled)
+                            Logger.Log($"Row {rowIndex}: ADDED — Time={point.Time:F2} Acceleration={point.Acceleration}");
 
                         rowIndex++;
                     }

--- a/src/CastleOverlayV2/Services/Logger.cs
+++ b/src/CastleOverlayV2/Services/Logger.cs
@@ -8,6 +8,10 @@ namespace CastleOverlayV2.Services
         private static bool _enabled = false;
         private static string _logPath = "";
 
+        // Gate hot-path interpolated calls with `if (Logger.IsEnabled) Logger.Log(...)`
+        // so the message string isn't built when logging is disabled.
+        public static bool IsEnabled => _enabled;
+
         public static void Init(bool enableLogging)
         {
             _enabled = enableLogging;

--- a/src/CastleOverlayV2/Services/RaceBoxLoader.cs
+++ b/src/CastleOverlayV2/Services/RaceBoxLoader.cs
@@ -81,9 +81,12 @@ namespace CastleOverlayV2.Services
 
                 string[] headers = allRows[telemetryHeaderRow];
 
-                Logger.Log("[RaceBoxLoader] Columns detected:");
-                foreach (var h in headers)
-                    Logger.Log($"  Header: '{h}'");
+                if (Logger.IsEnabled)
+                {
+                    Logger.Log("[RaceBoxLoader] Columns detected:");
+                    foreach (var h in headers)
+                        Logger.Log($"  Header: '{h}'");
+                }
 
                 Logger.Log($"[RaceBoxLoader] Header row columns: {headers.Length}");
 


### PR DESCRIPTION
## Summary
Closes #51. Stops paying for `$"...{x}..."` interpolation at hot logger call sites when debug logging is off.

## Diff
5 files changed, +36 / -17.

## What changed
- **`Logger.IsEnabled`** — new `public static bool` property exposing the existing internal flag.
- Gate the five hottest call sites:

| Site | Why it's hot |
|---|---|
| `CsvLoader` per-row `ADDED` log | Fires once per CSV row — thousands per file. Biggest single win. |
| `RaceBoxLoader` per-header-column log | ~30 iters per load. |
| `PlotManager.SetInitialChannelVisibility` per-channel loop | ~12 iters per replot. |
| `PlotManager.LogVisibilityStates` | Early-return at function top. |
| `MainForm.PlotAllRuns` slot + channel diagnostics | ~18 logs per toggle/load/delete/mode-change. |

## What's not gated (deliberately)
- Singleton diagnostic logs that fire once per user action (load button click, etc.). Cost is negligible.
- The `if (i % 100 == 0)` throttled RaceBox loop log — string is only built every 100th iteration already.
- The 60+ `MainForm.cs` logs that fire once per UI interaction.

The issue explicitly recommended gating only the 5–10 worst hot spots, not the whole codebase.

## Behavior
- **Logging enabled:** identical output.
- **Logging disabled (default):** no string allocation at gated sites.

## Tests
\`\`\`
Passed!  - Failed: 0, Passed: 28, Skipped: 0, Total: 28
\`\`\`

## Test plan
- [ ] Default (logging off): app behaviour unchanged; no log file written.
- [ ] Enable `EnableDebugLogging` in config.json. Load a Castle CSV — `Row N: ADDED` lines still appear in the log.
- [ ] PlotAllRuns triggers still produce the channel-visibility map in the log when enabled.

## Workflow
Per repo `CLAUDE.md`: yours to merge — I will not run `gh pr merge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)