### PR TITLE
refactor: extract business logic into MainFormPresenter (closes #57)

### DIFF
--- a/src/CastleOverlayV2/MainForm.cs
+++ b/src/CastleOverlayV2/MainForm.cs
@@ -6,9 +6,7 @@ using CastleOverlayV2.Services;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Drawing.Drawing2D;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -17,1136 +15,353 @@ namespace CastleOverlayV2
 {
     public partial class MainForm : Form
     {
-        private readonly PlotManager _plotManager;
-
-        // ✅ Config (preserved as-is)
         private readonly ConfigService _configService;
-
-        // Active runs by slot (Castle = slots 1–3, RaceBox = slots 4–6).
-        // Presence in the dict == has a loaded run; absence == empty slot.
-        private readonly Dictionary<int, RunData> _runs = new();
-
-        // ✅ RaceBox slots (Stage 1 only uses header metadata)
-        private RaceBoxData raceBox1;
-        private RaceBoxData raceBox2;
-        private RaceBoxData raceBox3;
-
+        private readonly PlotManager _plotManager;
         private ChannelToggleBar _channelToggleBar;
-
-        private bool _isFourPoleMode = false;
-
-        // 🆕 Nudge step sizes (ms) when using modifiers
-        private const double SHIFT_FINE_MS = 1;     // Ctrl
-        private const double SHIFT_NORMAL_MS = 100; // No modifier (only when you explicitly want ms mode)
-        private const double SHIFT_COARSE_MS = 1000; // Shift
+        private MainFormPresenter _presenter;
 
         public MainForm(ConfigService configService)
         {
-            // 0) Store config service (fallback just in case)
             _configService = configService ?? new ConfigService();
 
-            // 1) Create all WinForms controls first
             InitializeComponent();
 
-            // 2) Apply UI state that does not depend on PlotManager yet
-            ApplyRunTypeUI();
-            UpdateRunTypeLockState();
-
-            // 3) App icon & title
+            // App icon + title
             var iconStream = Assembly.GetExecutingAssembly()
                 .GetManifestResourceStream("CastleOverlayV2.Resources.DragOverlay.ico");
             if (iconStream != null)
                 this.Icon = new Icon(iconStream);
-
-            string buildNumber = _configService.GetBuildNumber();
-            this.Text = $"DragOverlay — Build {buildNumber}";
+            this.Text = $"DragOverlay — Build {_configService.GetBuildNumber()}";
 
             Logger.Log("MainForm initialized");
-            Logger.Log("=======================================");
             Logger.Log($"🟢 New Session Started — {DateTime.Now}");
-            Logger.Log("=======================================");
 
-            // 4) Disable toggles/deletes at startup (Castle + RaceBox)
-            btnToggleRun1.Enabled = false;
-            btnDeleteRun1.Enabled = false;
-            btnToggleRun2.Enabled = false;
-            btnDeleteRun2.Enabled = false;
-            btnToggleRun3.Enabled = false;
-            btnDeleteRun3.Enabled = false;
-
-            btnToggleRaceBox1.Enabled = false;
-            btnDeleteRaceBox1.Enabled = false;
-            btnToggleRaceBox2.Enabled = false;
-            btnDeleteRaceBox2.Enabled = false;
-            btnToggleRaceBox3.Enabled = false;
-            btnDeleteRaceBox3.Enabled = false;
-
-            // 5) Disable all shift buttons at startup
-            SetShiftButtonsEnabled(1, false, isRaceBox: false);
-            SetShiftButtonsEnabled(2, false, isRaceBox: false);
-            SetShiftButtonsEnabled(3, false, isRaceBox: false);
-            SetShiftButtonsEnabled(1, false, isRaceBox: true);
-            SetShiftButtonsEnabled(2, false, isRaceBox: true);
-            SetShiftButtonsEnabled(3, false, isRaceBox: true);
-
-            // 6) Maximize on startup
-            this.WindowState = FormWindowState.Maximized;
-
-            // 7) Pull config once
-            var config = _configService.Config;
-
-            Logger.Log("Config loaded at startup:");
-            if (config.ChannelVisibility != null)
+            // Disable per-slot action buttons until a run is loaded.
+            DisableAllSlotButtons();
+            for (int i = 1; i <= 3; i++)
             {
-                foreach (var kvp in config.ChannelVisibility)
-                    Logger.Log($"  Channel: {kvp.Key}, Visible: {kvp.Value}");
+                SetSlotShiftButtonsEnabled(i, false, isRaceBox: false);
+                SetSlotShiftButtonsEnabled(i, false, isRaceBox: true);
             }
 
-            // 8) Create PlotManager AFTER formsPlot1 exists
-            _plotManager = new Plot.PlotManager(formsPlot1);
+            this.WindowState = FormWindowState.Maximized;
+
+            // PlotManager needs formsPlot1, which exists after InitializeComponent().
+            _plotManager = new PlotManager(formsPlot1);
             formsPlot1.Dock = DockStyle.Fill;
-
-            // 9) Start in DRAG profile (Speed-Run OFF) unless your UI flips it later
-            _isSpeedRunMode = false;                       // <— removed Config.RunType usage
-            _plotManager.SetSpeedMode(_isSpeedRunMode);    // sets the scale profile
-
-            // 10) Build all axes and lock Castle Y ranges
             _plotManager.SetupAllAxes();
 
-            // 11) Channel list (canonical names)
+            // Build canonical channel list + normalize saved visibility keys.
             var channelNames = new List<string>
-    {
-        "RPM",
-        "Throttle %",
-        "Voltage",
-        "Current",
-        "Ripple",
-        "PowerOut",
-        "MotorTemp",
-        "ESC Temp",
-        "MotorTiming",
-        "Acceleration"
-    };
-
-            // 12) Normalize saved visibility keys (map legacy/typos → canonical)
-            var rawStates = config.ChannelVisibility ?? new Dictionary<string, bool>();
+            {
+                "RPM", "Throttle %", "Voltage", "Current", "Ripple",
+                "PowerOut", "MotorTemp", "ESC Temp", "MotorTiming", "Acceleration"
+            };
+            var rawStates = _configService.Config.ChannelVisibility ?? new Dictionary<string, bool>();
             var initialStates = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
             foreach (var kv in rawStates)
             {
                 string key = kv.Key;
-
                 if (key.Equals("Throttle", StringComparison.OrdinalIgnoreCase) ||
                     key.Equals("Throttle %.", StringComparison.OrdinalIgnoreCase))
                     key = "Throttle %";
-
-                initialStates[key] = kv.Value; // last-one-wins
+                initialStates[key] = kv.Value;
             }
-
-            // (optional) persist normalized map
             _configService.Config.ChannelVisibility = initialStates;
-            // _configService.Save();
-
-            // 13) Give PlotManager the initial visibility map BEFORE any runs are plotted
             _plotManager.SetInitialChannelVisibility(initialStates);
 
-            // 14) Build the toggle bar with canonical channels and states
             _channelToggleBar = new ChannelToggleBar(channelNames, initialStates);
-            _channelToggleBar.ChannelVisibilityChanged += OnChannelVisibilityChanged;
-            _channelToggleBar.RpmModeChanged += OnRpmModeChanged;
             Controls.Add(_channelToggleBar);
 
-            // 15) Inject any valid channels that exist in config but weren’t in the default list
+            // Inject any extra known channels found in config but missing from the default list.
             var allowed = new HashSet<string>(channelNames, StringComparer.OrdinalIgnoreCase);
             foreach (var kv in initialStates)
             {
-                if (!allowed.Contains(kv.Key))
-                    continue;
+                if (!allowed.Contains(kv.Key)) continue;
                 if (!_channelToggleBar.GetChannelStates().ContainsKey(kv.Key))
-                {
-                    Logger.Log($"🧩 Adding extra config channel to toggle bar: {kv.Key} → {kv.Value}");
                     _channelToggleBar.AddChannel(kv.Key, kv.Value);
-                }
             }
 
-            // 16) Apply RPM 4-pole/2-pole mode last (affects RPM axis lock max)
-            _isFourPoleMode = config.IsFourPoleMode;
-            _plotManager.SetFourPoleMode(_isFourPoleMode);
-
-            // 17) Start with an empty plot message and wire cursor callback
             _plotManager.ResetEmptyPlot();
-            _plotManager.CursorMoved += OnCursorMoved;
+
+            // Presenter owns all run state + business logic. It subscribes to plot/toggle events.
+            _presenter = new MainFormPresenter(this, _configService, _plotManager, _channelToggleBar);
+
+            // RunType pill: initial appearance (Drag mode, no runs loaded → not locked).
+            ApplyRunTypeUI(_presenter.IsSpeedRunMode);
+            UpdateRunTypeLockState();
         }
 
+        // =====================================================================
+        // Public view methods called by the Presenter
+        // =====================================================================
 
-        /// <summary>
-        /// ✅ Helper: Shorten a file name for button text
-        /// </summary>
-        private static string TruncateFileName(string filePath, int maxChars = 28)
+        /// <summary>Open file picker; null if cancelled.</summary>
+        public string? PickCsvFile()
         {
-            string fileName = Path.GetFileName(filePath) ?? string.Empty;
-            if (fileName.Length <= maxChars) return fileName;
-            if (maxChars <= 3) return fileName.Substring(0, maxChars);
-            return fileName.Substring(0, maxChars - 3) + "...";
-        }
-
-        /// <summary>
-        /// ✅ New: Load Run 1 slot
-        /// </summary>
-        private async void LoadRun1Button_Click(object sender, EventArgs e)
-        {
-            LogClick("Load Run 1");
-            Logger.Log("LoadRun1Button_Click started");
-
-            string filePath = GetCsvFilePath();
-            if (filePath == null) return;
-
-            try
+            using var ofd = new OpenFileDialog
             {
-                var loader = new CsvLoader(_configService);
-                var loaded = await Task.Run(() => loader.Load(filePath, trimForDrag: (_isSpeedRunMode == false)));
+                Title = "Select CSV file",
+                Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*"
+            };
+            return ofd.ShowDialog() == DialogResult.OK ? ofd.FileName : null;
+        }
 
-                if (loaded != null && loaded.DataPoints.Count > 0)
-                {
-                    _runs[1] = loaded;
-                    Logger.Log($"Loaded log: Run 1 - {Path.GetFileName(filePath)} - {loaded.DataPoints.Count} rows");
+        public void ShowError(string title, string message) =>
+            MessageBox.Show(message, title, MessageBoxButtons.OK, MessageBoxIcon.Error);
 
-                    _plotManager.SetRun(1, loaded);
-                    _plotManager.SetRunVisibility(1, true);
+        public void ShowInfo(string title, string message) =>
+            MessageBox.Show(message, title, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
-                    btnLoadRun1.Text = $"Run 1: {Path.GetFileName(filePath)}";
-
-                    PlotAllRuns();
-                    _plotManager.SetSpeedMode(_isSpeedRunMode);
-                    _plotManager.SetupAllAxes();
-
-                    _plotManager.RefreshPlot();
-
-                    btnToggleRun1.Text = _plotManager.GetRunVisibility(1) ? "Hide" : "Show";
+        /// <summary>A run was successfully loaded into <paramref name="slot"/>. Update button text + enable controls.</summary>
+        public void SetSlotLoadedUI(int slot, string loadButtonText, bool isVisible)
+        {
+            switch (slot)
+            {
+                case 1:
+                    btnLoadRun1.Text = loadButtonText;
                     btnToggleRun1.Enabled = true;
                     btnDeleteRun1.Enabled = true;
-
-                    SetShiftButtonsEnabled(1, true, isRaceBox: false);
-                }
-                else
-                {
-                    _runs.Remove(1);
-                    Logger.Log("Run 1 load failed or empty data.");
-                    MessageBox.Show("This file could not be loaded.\n\nIt may not be a valid Castle log or it contains no data.",
-                        "Import Failed", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.Log($"ERROR in Run1: {ex.Message}");
-                MessageBox.Show("An error occurred while loading the file.\n\n" + ex.Message,
-                    "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
-
-            UpdateRunTypeLockState();
-        }
-
-
-        /// <summary>
-        /// ✅ New: Load Run 2 slot
-        /// </summary>
-        private async void LoadRun2Button_Click(object sender, EventArgs e)
-        {
-            LogClick("Load Run 2");
-            Logger.Log("LoadRun2Button_Click started");
-
-            string filePath = GetCsvFilePath();
-            if (filePath == null) return;
-
-            try
-            {
-                var loader = new CsvLoader(_configService);
-                var loaded = await Task.Run(() => loader.Load(filePath, trimForDrag: (_isSpeedRunMode == false)));
-
-                if (loaded != null && loaded.DataPoints.Count > 0)
-                {
-                    _runs[2] = loaded;
-                    Logger.Log($"Loaded log: Run 2 - {Path.GetFileName(filePath)} - {loaded.DataPoints.Count} rows");
-
-                    _plotManager.SetRun(2, loaded);
-                    _plotManager.SetRunVisibility(2, true);
-
-                    btnLoadRun2.Text = $"Run 2: {Path.GetFileName(filePath)}";
-
-                    PlotAllRuns();
-                    _plotManager.SetSpeedMode(_isSpeedRunMode);
-                    _plotManager.SetupAllAxes();
-
-                    _plotManager.RefreshPlot();
-
-                    btnToggleRun2.Text = _plotManager.GetRunVisibility(2) ? "Hide" : "Show";
+                    btnToggleRun1.Text = isVisible ? "Hide" : "Show";
+                    SetSlotShiftButtonsEnabled(1, true, isRaceBox: false);
+                    break;
+                case 2:
+                    btnLoadRun2.Text = loadButtonText;
                     btnToggleRun2.Enabled = true;
                     btnDeleteRun2.Enabled = true;
-
-                    SetShiftButtonsEnabled(2, true, isRaceBox: false);
-                }
-                else
-                {
-                    _runs.Remove(2);
-                    Logger.Log("Run 2 load failed or empty data.");
-                    MessageBox.Show("This file could not be loaded.\n\nIt may not be a valid Castle log or it contains no data.",
-                        "Import Failed", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.Log($"ERROR in Run2: {ex.Message}");
-                MessageBox.Show("An error occurred while loading the file.\n\n" + ex.Message,
-                    "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
-
-            UpdateRunTypeLockState();
-        }
-
-
-        /// <summary>
-        /// ✅ New: Load Run 3 slot
-        /// </summary>
-        private async void LoadRun3Button_Click(object sender, EventArgs e)
-        {
-            LogClick("Load Run 3");
-            Logger.Log("LoadRun3Button_Click started");
-
-            string filePath = GetCsvFilePath();
-            if (filePath == null) return;
-
-            try
-            {
-                var loader = new CsvLoader(_configService);
-                var loaded = await Task.Run(() => loader.Load(filePath, trimForDrag: (_isSpeedRunMode == false)));
-
-                if (loaded != null && loaded.DataPoints.Count > 0)
-                {
-                    _runs[3] = loaded;
-                    Logger.Log($"Loaded log: Run 3 - {Path.GetFileName(filePath)} - {loaded.DataPoints.Count} rows");
-
-                    _plotManager.SetRun(3, loaded);
-                    _plotManager.SetRunVisibility(3, true);
-
-                    btnLoadRun3.Text = $"Run 3: {Path.GetFileName(filePath)}";
-
-                    PlotAllRuns();
-                    _plotManager.SetSpeedMode(_isSpeedRunMode);
-                    _plotManager.SetupAllAxes();
-
-                    _plotManager.RefreshPlot();
-
-                    btnToggleRun3.Text = _plotManager.GetRunVisibility(3) ? "Hide" : "Show";
+                    btnToggleRun2.Text = isVisible ? "Hide" : "Show";
+                    SetSlotShiftButtonsEnabled(2, true, isRaceBox: false);
+                    break;
+                case 3:
+                    btnLoadRun3.Text = loadButtonText;
                     btnToggleRun3.Enabled = true;
                     btnDeleteRun3.Enabled = true;
-
-                    SetShiftButtonsEnabled(3, true, isRaceBox: false);
-                }
-                else
-                {
-                    _runs.Remove(3);
-                    Logger.Log("Run 3 load failed or empty data.");
-                    MessageBox.Show("This file could not be loaded.\n\nIt may not be a valid Castle log or it contains no data.",
-                        "Import Failed", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.Log($"ERROR in Run3: {ex.Message}");
-                MessageBox.Show("An error occurred while loading the file.\n\n" + ex.Message,
-                    "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
-
-            UpdateRunTypeLockState();
-        }
-
-
-        /// <summary>
-        /// ✅ Load RaceBox CSV for Run 1 slot
-        /// </summary>
-        private async void LoadRaceBox1Button_Click(object sender, EventArgs e)
-        {
-            Logger.Log("RaceBox Load Button Clicked — Slot 1");
-
-            var path = GetCsvFilePath();
-            if (path == null) return;
-
-            try
-            {
-                Logger.Log("Opening file picker...");
-                Logger.Log($"Selected file: {path}");
-
-                var rbData = RaceBoxLoader.LoadHeaderOnly(path);
-
-                if (rbData == null)
-                {
-                    Logger.Log("[MainForm] RaceBox header loading failed — rbData is null");
-                    return;
-                }
-
-                if (rbData.FirstCompleteRunIndex == null)
-                {
-                    MessageBox.Show("No complete run found in this RaceBox file.", "Incomplete Run", MessageBoxButtons.OK, MessageBoxIcon.Information);
-                    return;
-                }
-
-                Logger.Log($"Header loaded: {rbData.RunCount} runs found, FirstCompleteRun = {rbData.FirstCompleteRunIndex + 1}");
-                Logger.Log("Parsing RaceBox telemetry for Slot 1...");
-
-                var loader = new RaceBoxLoader();
-
-                Logger.Log("[MainForm] Calling RaceBoxLoader.LoadTelemetry(...) now...");
-                var points = await Task.Run(() =>
-                    loader.LoadTelemetry(path, rbData.FirstCompleteRunIndex.Value)
-                );
-                Logger.Log("[MainForm] LoadTelemetry() returned successfully");
-
-                Logger.Log($"📈 RaceBox telemetry parsed: {points.Count} rows for Slot 1");
-
-                // ✅ Record number range logging
-                int firstRecord = points.First().Record;
-                int lastRecord = points.Last().Record;
-                Logger.Log($"📌 RaceBox Record range used for Slot 1: {firstRecord} → {lastRecord}");
-
-                raceBox1 = rbData;
-                Logger.Log($"✅ RaceBox 1 loaded. RunCount = {rbData.RunCount}, FirstCompleteRun = {rbData.FirstCompleteRunIndex + 1}");
-
-                // === ✅ Convert RaceBox points into RunData for plotting ===
-                var run = new RunData();
-                run.IsRaceBox = true;
-                run.SplitTimes = rbData.SplitTimes;
-                run.SplitLabels = rbData.SplitLabels;
-                run.FileName = Path.GetFileName(path);
-
-                // ✅ Store Castle-style DataPoints into per-channel dictionary
-                run.Data["RaceBox Speed"] = points.Select(p => new DataPoint
-                {
-                    Time = p.Time.TotalSeconds,
-                    Y = p.SpeedMph
-                }).ToList();
-
-                run.Data["RaceBox G-Force X"] = points.Select(p => new DataPoint
-                {
-                    Time = p.Time.TotalSeconds,
-                    Y = p.GForceX
-                }).ToList();
-
-                // ✅ REQUIRED: Populate dummy DataPoints list so plot manager doesn't skip it
-                run.DataPoints = points.Select(p => new DataPoint
-                {
-                    Time = p.Time.TotalSeconds
-                }).ToList();
-
-                Logger.Log($"✅ Run4 channels: {string.Join(", ", run.Data.Keys)}");
-
-                // === ✅ Assign RaceBox 1 into slot 4 (paired with Castle Run1) ===
-                _runs[4] = run;
-                _plotManager.SetRun(4, run); // ❗ Critical for visibility logic
-                _plotManager.SetRunVisibility(4, true);
-
-                // ✅ Show filename on the (now-wider) button
-                btnLoadRaceBox1.Text = $"RaceBox 1: {TruncateFileName(path)}";
-
-                btnToggleRaceBox1.Enabled = true;
-                btnDeleteRaceBox1.Enabled = true;
-
-                Logger.Log($"✅ Run1 channels: {string.Join(", ", run.Data.Keys)}");
-
-                // === 🆕 Add RaceBox channels to toggle bar if missing ===
-                var addedChannels = false;
-
-                if (!_channelToggleBar.GetChannelStates().ContainsKey("RaceBox Speed"))
-                {
-                    Logger.Log("🆕 Adding RaceBox Speed to toggle bar");
-                    _channelToggleBar.AddChannel("RaceBox Speed", true);
-                    addedChannels = true;
-                }
-                else
-                {
-                    Logger.Log("ℹ️ RaceBox Speed already exists in toggle bar");
-                }
-
-                if (!_channelToggleBar.GetChannelStates().ContainsKey("RaceBox G-Force X"))
-                {
-                    Logger.Log("🆕 Adding RaceBox G-Force X to toggle bar");
-                    _channelToggleBar.AddChannel("RaceBox G-Force X", true);
-                    addedChannels = true;
-                }
-                else
-                {
-                    Logger.Log("ℹ️ RaceBox G-Force X already exists in toggle bar");
-                }
-
-                if (addedChannels)
-                {
-                    Logger.Log("🔄 Forcing layout refresh after adding RaceBox toggles");
-                    _channelToggleBar.PerformLayout();
-                    _channelToggleBar.Refresh();
-                }
-
-                if (run.Data.TryGetValue("RaceBox Speed", out var speedPoints))
-                    Logger.Log($"✅ Run1 point count (Speed): {speedPoints.Count}");
-
-                if (run.Data.TryGetValue("RaceBox G-Force X", out var gxPoints))
-                    Logger.Log($"✅ Run1 point count (G-Force X): {gxPoints.Count}");
-
-                // 🆕 Enable shift controls for RaceBox slot 1 (slot 4)
-                SetShiftButtonsEnabled(1, true, isRaceBox: true);
-
-                PlotAllRuns();
-            }
-            catch (Exception ex)
-            {
-                Logger.Log($"ERROR in RaceBox1: {ex.Message}");
-                MessageBox.Show("An error occurred while loading the file.\n\n" + ex.Message,
-                    "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
-
-            UpdateRunTypeLockState();
-        }
-
-        private async void LoadRaceBox2Button_Click(object sender, EventArgs e)
-        {
-            Logger.Log("RaceBox Load Button Clicked — Slot 2");
-
-            var path = GetCsvFilePath();
-            if (path == null) return;
-
-            var rbData = RaceBoxLoader.LoadHeaderOnly(path);
-
-            if (rbData == null)
-            {
-                Logger.Log("[MainForm] LoadHeaderOnly returned null (invalid RaceBox file)");
-                return;
-            }
-
-            if (rbData.FirstCompleteRunIndex == null)
-            {
-                MessageBox.Show("No complete run found in this RaceBox file.", "Incomplete Run", MessageBoxButtons.OK, MessageBoxIcon.Information);
-                return;
-            }
-
-            Logger.Log($"Header loaded: {rbData.RunCount} runs found, FirstCompleteRun = {rbData.FirstCompleteRunIndex + 1}");
-            Logger.Log("Parsing RaceBox telemetry for Slot 2...");
-
-            var loader = new RaceBoxLoader();
-            var points = await Task.Run(() => loader.LoadTelemetry(path, rbData.FirstCompleteRunIndex.Value));
-
-            if (points == null || points.Count == 0)
-            {
-                Logger.Log("❌ RaceBox telemetry load failed or returned no points.");
-                MessageBox.Show("RaceBox telemetry is empty or could not be parsed.", "Telemetry Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                return;
-            }
-
-            Logger.Log($"📈 RaceBox telemetry parsed: {points.Count} rows for RaceBox2 → run5");
-
-            raceBox2 = rbData;
-
-            var run = new RunData();
-            run.IsRaceBox = true;
-            run.SplitTimes = rbData.SplitTimes;
-            run.SplitLabels = rbData.SplitLabels;
-            run.FileName = Path.GetFileName(path);
-
-            run.Data["RaceBox Speed"] = points.Select(p => new DataPoint { Time = p.Time.TotalSeconds, Y = p.SpeedMph }).ToList();
-            run.Data["RaceBox G-Force X"] = points.Select(p => new DataPoint { Time = p.Time.TotalSeconds, Y = p.GForceX }).ToList();
-            run.DataPoints = points.Select(p => new DataPoint { Time = p.Time.TotalSeconds }).ToList();
-
-            _runs[5] = run;
-
-            // ✅ Register run + enable buttons
-            _plotManager.SetRun(5, run);
-            _plotManager.SetRunVisibility(5, true);
-
-            // ✅ Show filename on the button
-            btnLoadRaceBox2.Text = $"RaceBox 2: {TruncateFileName(path)}";
-
-            btnToggleRaceBox2.Enabled = true;
-            btnDeleteRaceBox2.Enabled = true;
-
-            var addedChannels = false;
-
-            if (!_channelToggleBar.GetChannelStates().ContainsKey("RaceBox Speed"))
-            {
-                Logger.Log("🆕 Adding RaceBox Speed to toggle bar");
-                _channelToggleBar.AddChannel("RaceBox Speed", true);
-                addedChannels = true;
-            }
-
-            if (!_channelToggleBar.GetChannelStates().ContainsKey("RaceBox G-Force X"))
-            {
-                Logger.Log("🆕 Adding RaceBox G-Force X to toggle bar");
-                _channelToggleBar.AddChannel("RaceBox G-Force X", true);
-                addedChannels = true;
-            }
-
-            if (addedChannels)
-            {
-                _channelToggleBar.PerformLayout();
-                _channelToggleBar.Refresh();
-            }
-
-            // 🆕 Enable shift controls for RaceBox slot 2 (slot 5)
-            SetShiftButtonsEnabled(2, true, isRaceBox: true);
-
-            PlotAllRuns();
-
-            UpdateRunTypeLockState();
-        }
-
-        private async void LoadRaceBox3Button_Click(object sender, EventArgs e)
-        {
-            Logger.Log("RaceBox Load Button Clicked — Slot 3");
-
-            var path = GetCsvFilePath();
-            if (path == null) return;
-
-            try
-            {
-                var rbData = RaceBoxLoader.LoadHeaderOnly(path);
-                if (rbData == null)
-                {
-                    Logger.Log("[MainForm] RaceBox header load failed — rbData was null");
-                    return;
-                }
-
-                if (rbData.FirstCompleteRunIndex == null)
-                {
-                    MessageBox.Show("No complete run found in this RaceBox file.", "Incomplete Run", MessageBoxButtons.OK, MessageBoxIcon.Information);
-                    return;
-                }
-
-                Logger.Log($"Header loaded: {rbData.RunCount} runs found, FirstCompleteRun = {rbData.FirstCompleteRunIndex + 1}");
-                Logger.Log("Parsing RaceBox telemetry for Slot 3...");
-
-                var loader = new RaceBoxLoader();
-                var points = await Task.Run(() => loader.LoadTelemetry(path, rbData.FirstCompleteRunIndex.Value));
-
-                Logger.Log($"📈 RaceBox telemetry parsed: {points.Count} rows for RaceBox3 → run6");
-
-                raceBox3 = rbData;
-
-                var run = new RunData();
-                run.IsRaceBox = true;
-                run.FileName = Path.GetFileName(path);
-                run.SplitTimes = rbData.SplitTimes;
-                run.SplitLabels = rbData.SplitLabels;
-
-                run.Data["RaceBox Speed"] = points.Select(p => new DataPoint { Time = p.Time.TotalSeconds, Y = p.SpeedMph }).ToList();
-                run.Data["RaceBox G-Force X"] = points.Select(p => new DataPoint { Time = p.Time.TotalSeconds, Y = p.GForceX }).ToList();
-                run.DataPoints = points.Select(p => new DataPoint { Time = p.Time.TotalSeconds }).ToList();
-
-                _runs[6] = run;
-
-                // ✅ Register run + enable buttons
-                _plotManager.SetRun(6, run);
-                _plotManager.SetRunVisibility(6, true);
-
-                // ✅ Show filename on the button
-                btnLoadRaceBox3.Text = $"RaceBox 3: {TruncateFileName(path)}";
-
-                btnToggleRaceBox3.Enabled = true;
-                btnDeleteRaceBox3.Enabled = true;
-
-                var addedChannels = false;
-
-                if (!_channelToggleBar.GetChannelStates().ContainsKey("RaceBox Speed"))
-                {
-                    Logger.Log("🆕 Adding RaceBox Speed to toggle bar");
-                    _channelToggleBar.AddChannel("RaceBox Speed", true);
-                    addedChannels = true;
-                }
-
-                if (!_channelToggleBar.GetChannelStates().ContainsKey("RaceBox G-Force X"))
-                {
-                    Logger.Log("🆕 Adding RaceBox G-Force X to toggle bar");
-                    _channelToggleBar.AddChannel("RaceBox G-Force X", true);
-                    addedChannels = true;
-                }
-
-                if (addedChannels)
-                {
-                    _channelToggleBar.PerformLayout();
-                    _channelToggleBar.Refresh();
-                }
-
-                // 🆕 Enable shift controls for RaceBox slot 3 (slot 6)
-                SetShiftButtonsEnabled(3, true, isRaceBox: true);
-
-                PlotAllRuns();
-            }
-            catch (Exception ex)
-            {
-                Logger.Log($"ERROR in RaceBox3: {ex.Message}");
-                MessageBox.Show("An error occurred while loading the file.\n\n" + ex.Message,
-                    "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
-
-            UpdateRunTypeLockState();
-        }
-
-        private string GetCsvFilePath()
-        {
-            Logger.Log("Opening file picker...");
-
-            using (var ofd = new OpenFileDialog())
-            {
-                ofd.Title = "Select CSV file";
-                ofd.Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*";
-
-                var result = ofd.ShowDialog();
-                Logger.Log($"File dialog result: {result}");
-
-                if (result == DialogResult.OK)
-                {
-                    Logger.Log($"Selected file: {ofd.FileName}");
-                    return ofd.FileName;
-                }
-                else
-                {
-                    Logger.Log("No file selected.");
-                    return null;
-                }
+                    btnToggleRun3.Text = isVisible ? "Hide" : "Show";
+                    SetSlotShiftButtonsEnabled(3, true, isRaceBox: false);
+                    break;
+                case 4:
+                    btnLoadRaceBox1.Text = loadButtonText;
+                    btnToggleRaceBox1.Enabled = true;
+                    btnDeleteRaceBox1.Enabled = true;
+                    btnToggleRaceBox1.Text = isVisible ? "Hide" : "Show";
+                    SetSlotShiftButtonsEnabled(1, true, isRaceBox: true);
+                    break;
+                case 5:
+                    btnLoadRaceBox2.Text = loadButtonText;
+                    btnToggleRaceBox2.Enabled = true;
+                    btnDeleteRaceBox2.Enabled = true;
+                    btnToggleRaceBox2.Text = isVisible ? "Hide" : "Show";
+                    SetSlotShiftButtonsEnabled(2, true, isRaceBox: true);
+                    break;
+                case 6:
+                    btnLoadRaceBox3.Text = loadButtonText;
+                    btnToggleRaceBox3.Enabled = true;
+                    btnDeleteRaceBox3.Enabled = true;
+                    btnToggleRaceBox3.Text = isVisible ? "Hide" : "Show";
+                    SetSlotShiftButtonsEnabled(3, true, isRaceBox: true);
+                    break;
             }
         }
 
-        /// <summary>
-        /// ✅ Helper: Collect non-null runs and plot all
-        /// </summary>
-        private void PlotAllRuns()
+        /// <summary>Reset a slot's per-slot buttons to the empty/unloaded state.</summary>
+        public void ResetSlotUI(int slot)
         {
-            if (Logger.IsEnabled)
-            {
-                Logger.Log("PlotAllRuns called with runs:");
-                foreach (var (slot, run) in _runs)
-                    Logger.Log($"  Run {slot}: {run.DataPoints.Count} points, shift={run.TimeShiftMs} ms");
-            }
-
-            var visibilityMap = _channelToggleBar.GetChannelStates();
-
-            if (Logger.IsEnabled)
-            {
-                Logger.Log("PlotAllRuns — Channel visibility map before applying:");
-                foreach (var kvp in visibilityMap)
-                    Logger.Log($"  Channel: {kvp.Key}, Visible: {kvp.Value}");
-            }
-
-            _plotManager.SetInitialChannelVisibility(visibilityMap);
-            _plotManager.PlotRuns(new Dictionary<int, RunData>(_runs));
-        }
-
-        /// <summary>
-        /// Toggle changed — update plot visibility surgically and persist to config.
-        /// </summary>
-        private void OnChannelVisibilityChanged(string channelName, bool isVisible)
-        {
-            Logger.Log($"📎 Channel toggle clicked: {channelName} → {(isVisible ? "Show" : "Hide")}");
-
-            // Fix #48: SetChannelVisibility already updates per-scatter IsVisible and refreshes.
-            // The previous full PlotAllRuns() call here was redundant double work.
-            _plotManager.SetChannelVisibility(channelName, isVisible);
-
-            _configService.SetChannelVisibility(channelName, isVisible);
-        }
-
-        /// <summary>
-        /// ✅ Hover data updates toggle bar
-        /// </summary>
-        private void OnCursorMoved(Dictionary<string, double?[]> valuesAtCursor)
-        {
-            _channelToggleBar.UpdateMousePositionValues(valuesAtCursor);
-        }
-
-        private void ToggleRun1Button_Click(object sender, EventArgs e)
-        {
-            LogClick("Toggle Run 1");
-            bool isNowVisible = _plotManager.ToggleRunVisibility(1);
-            btnToggleRun1.Text = isNowVisible ? "Hide" : "Show";
-        }
-
-        private void ToggleRun2Button_Click(object sender, EventArgs e)
-        {
-            LogClick("Toggle Run 2");
-            bool isNowVisible = _plotManager.ToggleRunVisibility(2);
-            btnToggleRun2.Text = isNowVisible ? "Hide" : "Show";
-        }
-
-        private void ToggleRun3Button_Click(object sender, EventArgs e)
-        {
-            LogClick("Toggle Run 3");
-            bool isNowVisible = _plotManager.ToggleRunVisibility(3);
-            btnToggleRun3.Text = isNowVisible ? "Hide" : "Show";
-        }
-
-        private void DeleteRun1Button_Click(object sender, EventArgs e)
-        {
-            LogClick("Delete Run 1");
-            DeleteRun(1);
-
-        }
-
-        private void DeleteRun2Button_Click(object sender, EventArgs e)
-        {
-            LogClick("Delete Run 2");
-            DeleteRun(2);
-        }
-
-        private void DeleteRun3Button_Click(object sender, EventArgs e)
-        {
-            LogClick("Delete Run 3");
-            DeleteRun(3);
-        }
-
-        private void DeleteRun(int slot)
-        {
-            _runs.Remove(slot);
-
-            // Per-slot button cleanup. Buttons are Designer-named so the switch stays.
             switch (slot)
             {
                 case 1:
                     btnLoadRun1.Enabled = true;
-                    btnToggleRun1.Enabled = false;
-                    btnDeleteRun1.Enabled = false;
-                    btnToggleRun1.Text = "Hide";
                     btnLoadRun1.Text = "Load Run 1";
-                    SetShiftButtonsEnabled(1, false, isRaceBox: false);
+                    btnToggleRun1.Enabled = false;
+                    btnToggleRun1.Text = "Hide";
+                    btnDeleteRun1.Enabled = false;
+                    SetSlotShiftButtonsEnabled(1, false, isRaceBox: false);
                     break;
                 case 2:
                     btnLoadRun2.Enabled = true;
-                    btnToggleRun2.Enabled = false;
-                    btnDeleteRun2.Enabled = false;
-                    btnToggleRun2.Text = "Hide";
                     btnLoadRun2.Text = "Load Run 2";
-                    SetShiftButtonsEnabled(2, false, isRaceBox: false);
+                    btnToggleRun2.Enabled = false;
+                    btnToggleRun2.Text = "Hide";
+                    btnDeleteRun2.Enabled = false;
+                    SetSlotShiftButtonsEnabled(2, false, isRaceBox: false);
                     break;
                 case 3:
                     btnLoadRun3.Enabled = true;
-                    btnToggleRun3.Enabled = false;
-                    btnDeleteRun3.Enabled = false;
-                    btnToggleRun3.Text = "Hide";
                     btnLoadRun3.Text = "Load Run 3";
-                    SetShiftButtonsEnabled(3, false, isRaceBox: false);
+                    btnToggleRun3.Enabled = false;
+                    btnToggleRun3.Text = "Hide";
+                    btnDeleteRun3.Enabled = false;
+                    SetSlotShiftButtonsEnabled(3, false, isRaceBox: false);
                     break;
                 case 4:
                     btnLoadRaceBox1.Enabled = true;
-                    btnToggleRaceBox1.Enabled = false;
-                    btnDeleteRaceBox1.Enabled = false;
-                    btnToggleRaceBox1.Text = "Hide";
                     btnLoadRaceBox1.Text = "Load RaceBox 1";
-                    SetShiftButtonsEnabled(1, false, isRaceBox: true);
+                    btnToggleRaceBox1.Enabled = false;
+                    btnToggleRaceBox1.Text = "Hide";
+                    btnDeleteRaceBox1.Enabled = false;
+                    SetSlotShiftButtonsEnabled(1, false, isRaceBox: true);
                     break;
                 case 5:
                     btnLoadRaceBox2.Enabled = true;
-                    btnToggleRaceBox2.Enabled = false;
-                    btnDeleteRaceBox2.Enabled = false;
-                    btnToggleRaceBox2.Text = "Hide";
                     btnLoadRaceBox2.Text = "Load RaceBox 2";
-                    SetShiftButtonsEnabled(2, false, isRaceBox: true);
+                    btnToggleRaceBox2.Enabled = false;
+                    btnToggleRaceBox2.Text = "Hide";
+                    btnDeleteRaceBox2.Enabled = false;
+                    SetSlotShiftButtonsEnabled(2, false, isRaceBox: true);
                     break;
                 case 6:
                     btnLoadRaceBox3.Enabled = true;
-                    btnToggleRaceBox3.Enabled = false;
-                    btnDeleteRaceBox3.Enabled = false;
-                    btnToggleRaceBox3.Text = "Hide";
                     btnLoadRaceBox3.Text = "Load RaceBox 3";
-                    SetShiftButtonsEnabled(3, false, isRaceBox: true);
+                    btnToggleRaceBox3.Enabled = false;
+                    btnToggleRaceBox3.Text = "Hide";
+                    btnDeleteRaceBox3.Enabled = false;
+                    SetSlotShiftButtonsEnabled(3, false, isRaceBox: true);
                     break;
             }
-
-            // Force hide the run on the plot if PlotManager still has it visible.
-            if (_plotManager.GetRunVisibility(slot))
-                _plotManager.ToggleRunVisibility(slot);
-
-            _plotManager.PlotRuns(new Dictionary<int, RunData>(_runs));
         }
 
-        private void OnRpmModeChanged(bool isFourPole)
+        /// <summary>Update a slot's toggle button label ("Hide"/"Show") after a visibility flip.</summary>
+        public void SetSlotToggleText(int slot, bool isVisible)
         {
-            _isFourPoleMode = isFourPole;
-            _plotManager.SetFourPoleMode(_isFourPoleMode);
-
-            // Fix #46: replot ALL runs (Castle + RaceBox), not just slots 1–3.
-            PlotAllRuns();
-
-            _configService.SetRpmMode(isFourPole);
-        }
-
-        private void LogClick(string buttonName)
-        {
-            Logger.Log($" 🔘 Button clicked: {buttonName}");
-        }
-
-        // ================================
-        // RaceBox: consolidated handlers
-        // ================================
-        private void ToggleRaceBox(int slot, Button toggleButtonOrNull)
-        {
-            LogClick($"Toggle RaceBox {slot - 3}"); // slots 4..6 → labels 1..3
-
-            bool isVisible = _plotManager.ToggleRunVisibility(slot);
-
-            // Only update button text if a real button was passed and it’s visible in the layout
-            if (toggleButtonOrNull != null && !toggleButtonOrNull.IsDisposed && toggleButtonOrNull.Visible)
-                toggleButtonOrNull.Text = isVisible ? "Hide" : "Show";
-
-            Logger.Log($"🔁 Toggled RaceBox Run {slot - 3} visibility → {(isVisible ? "Visible" : "Hidden")}");
-        }
-
-        private void DeleteRaceBox(int slot)
-        {
-            LogClick($"Delete RaceBox {slot - 3}");
-            DeleteRun(slot); // central delete logic handles UI + plot + UpdateRunTypeLockState()
-        }
-
-        // ==== Wrappers kept for existing event wires (buttons or menus) ====
-        private void ToggleRaceBox1Button_Click(object sender, EventArgs e) => ToggleRaceBox(4, btnToggleRaceBox1);
-        private void ToggleRaceBox2Button_Click(object sender, EventArgs e) => ToggleRaceBox(5, btnToggleRaceBox2);
-        private void ToggleRaceBox3Button_Click(object sender, EventArgs e) => ToggleRaceBox(6, btnToggleRaceBox3);
-
-        private void DeleteRaceBox1Button_Click(object sender, EventArgs e) => DeleteRaceBox(4);
-        private void DeleteRaceBox2Button_Click(object sender, EventArgs e) => DeleteRaceBox(5);
-        private void DeleteRaceBox3Button_Click(object sender, EventArgs e) => DeleteRaceBox(6);
-
-
-        // ======================================================================================
-        // 🆕 Time-shift helpers and handlers
-
-        // Returns the user-requested delta for this click:
-        // - Ctrl → fine ms, Shift → coarse ms
-        // - No modifier → exactly one “dot” (median Δt) for this slot
-        private double GetClickDeltaMs(int slot)
-        {
-            if ((ModifierKeys & Keys.Control) == Keys.Control) return SHIFT_FINE_MS;
-            if ((ModifierKeys & Keys.Shift) == Keys.Shift) return SHIFT_COARSE_MS;
-
-            // Default: one sample step (“one dot”)
-            double stepSec = _plotManager.GetSampleStepSeconds(slot);
-            if (stepSec <= 0) stepSec = 0.01; // safety
-            return stepSec * 1000.0;
-        }
-
-        private void ApplyShift(int slot, double deltaMs)
-        {
-            if (!_runs.TryGetValue(slot, out var run)) return;
-            run.TimeShiftMs += deltaMs;
-            Logger.Log($"⏱️ Run {slot} shift {(deltaMs >= 0 ? "+" : "")}{deltaMs} ms → total {run.TimeShiftMs} ms");
-            PlotAllRuns();
-        }
-
-        private void ResetShift(int slot)
-        {
-            if (!_runs.TryGetValue(slot, out var run)) return;
-            run.TimeShiftMs = 0;
-            Logger.Log($"⏱️ Run {slot} shift reset → 0 ms");
-            PlotAllRuns();
-        }
-
-        private void SetShiftButtonsEnabled(int slotIndex, bool enabled, bool isRaceBox)
-        {
-            if (!isRaceBox)
+            string txt = isVisible ? "Hide" : "Show";
+            switch (slot)
             {
-                switch (slotIndex)
-                {
-                    case 1:
-                        btnShiftLeftRun1.Enabled = enabled;
-                        btnShiftRightRun1.Enabled = enabled;
-                        btnShiftResetRun1.Enabled = enabled;
-                        break;
-                    case 2:
-                        btnShiftLeftRun2.Enabled = enabled;
-                        btnShiftRightRun2.Enabled = enabled;
-                        btnShiftResetRun2.Enabled = enabled;
-                        break;
-                    case 3:
-                        btnShiftLeftRun3.Enabled = enabled;
-                        btnShiftRightRun3.Enabled = enabled;
-                        btnShiftResetRun3.Enabled = enabled;
-                        break;
-                }
-            }
-            else
-            {
-                switch (slotIndex)
-                {
-                    case 1:
-                        btnShiftLeftRB1.Enabled = enabled;
-                        btnShiftRightRB1.Enabled = enabled;
-                        btnShiftResetRB1.Enabled = enabled;
-                        break;
-                    case 2:
-                        btnShiftLeftRB2.Enabled = enabled;
-                        btnShiftRightRB2.Enabled = enabled;
-                        btnShiftResetRB2.Enabled = enabled;
-                        break;
-                    case 3:
-                        btnShiftLeftRB3.Enabled = enabled;
-                        btnShiftRightRB3.Enabled = enabled;
-                        btnShiftResetRB3.Enabled = enabled;
-                        break;
-                }
+                case 1: btnToggleRun1.Text = txt; break;
+                case 2: btnToggleRun2.Text = txt; break;
+                case 3: btnToggleRun3.Text = txt; break;
+                case 4: if (!btnToggleRaceBox1.IsDisposed && btnToggleRaceBox1.Visible) btnToggleRaceBox1.Text = txt; break;
+                case 5: if (!btnToggleRaceBox2.IsDisposed && btnToggleRaceBox2.Visible) btnToggleRaceBox2.Text = txt; break;
+                case 6: if (!btnToggleRaceBox3.IsDisposed && btnToggleRaceBox3.Visible) btnToggleRaceBox3.Text = txt; break;
             }
         }
 
-        // --- Run 1 (Castle slot 1)
-        private void ShiftLeftRun1_Click(object sender, EventArgs e) => ApplyShift(1, -GetClickDeltaMs(1));
-        private void ShiftRightRun1_Click(object sender, EventArgs e) => ApplyShift(1, +GetClickDeltaMs(1));
-        private void ShiftResetRun1_Click(object sender, EventArgs e) => ResetShift(1);
+        /// <summary>Sync the RunType pill switch appearance with current mode + lock state.</summary>
+        public void UpdateRunTypeLockState() => SyncRunTypeUI(_presenter?.IsSpeedRunMode ?? false, _presenter?.IsAnyRunLoaded ?? false);
 
-        // --- Run 2 (Castle slot 2)
-        private void ShiftLeftRun2_Click(object sender, EventArgs e) => ApplyShift(2, -GetClickDeltaMs(2));
-        private void ShiftRightRun2_Click(object sender, EventArgs e) => ApplyShift(2, +GetClickDeltaMs(2));
-        private void ShiftResetRun2_Click(object sender, EventArgs e) => ResetShift(2);
+        // =====================================================================
+        // Designer-wired button handlers — all 1-line forwarders to the Presenter
+        // =====================================================================
 
-        // --- Run 3 (Castle slot 3)
-        private void ShiftLeftRun3_Click(object sender, EventArgs e) => ApplyShift(3, -GetClickDeltaMs(3));
-        private void ShiftRightRun3_Click(object sender, EventArgs e) => ApplyShift(3, +GetClickDeltaMs(3));
-        private void ShiftResetRun3_Click(object sender, EventArgs e) => ResetShift(3);
+        // -- Castle load --
+        private async void LoadRun1Button_Click(object sender, EventArgs e) => await _presenter.LoadCastleRunAsync(1);
+        private async void LoadRun2Button_Click(object sender, EventArgs e) => await _presenter.LoadCastleRunAsync(2);
+        private async void LoadRun3Button_Click(object sender, EventArgs e) => await _presenter.LoadCastleRunAsync(3);
 
-        // --- RaceBox 1 (slot 4, UI group 1)
-        private void ShiftLeftRB1_Click(object sender, EventArgs e) => ApplyShift(4, -GetClickDeltaMs(4));
-        private void ShiftRightRB1_Click(object sender, EventArgs e) => ApplyShift(4, +GetClickDeltaMs(4));
-        private void ShiftResetRB1_Click(object sender, EventArgs e) => ResetShift(4);
+        // -- RaceBox load (UI slots 1..3 → plot slots 4..6) --
+        private async void LoadRaceBox1Button_Click(object sender, EventArgs e) => await _presenter.LoadRaceBoxRunAsync(1);
+        private async void LoadRaceBox2Button_Click(object sender, EventArgs e) => await _presenter.LoadRaceBoxRunAsync(2);
+        private async void LoadRaceBox3Button_Click(object sender, EventArgs e) => await _presenter.LoadRaceBoxRunAsync(3);
 
-        // --- RaceBox 2 (slot 5, UI group 2)
-        private void ShiftLeftRB2_Click(object sender, EventArgs e) => ApplyShift(5, -GetClickDeltaMs(5));
-        private void ShiftRightRB2_Click(object sender, EventArgs e) => ApplyShift(5, +GetClickDeltaMs(5));
-        private void ShiftResetRB2_Click(object sender, EventArgs e) => ResetShift(5);
+        // -- Castle toggle --
+        private void ToggleRun1Button_Click(object sender, EventArgs e) => _presenter.ToggleRun(1);
+        private void ToggleRun2Button_Click(object sender, EventArgs e) => _presenter.ToggleRun(2);
+        private void ToggleRun3Button_Click(object sender, EventArgs e) => _presenter.ToggleRun(3);
 
-        // --- RaceBox 3 (slot 6, UI group 3)
-        private void ShiftLeftRB3_Click(object sender, EventArgs e) => ApplyShift(6, -GetClickDeltaMs(6));
-        private void ShiftRightRB3_Click(object sender, EventArgs e) => ApplyShift(6, +GetClickDeltaMs(6));
-        private void ShiftResetRB3_Click(object sender, EventArgs e) => ResetShift(6);
+        // -- RaceBox toggle --
+        private void ToggleRaceBox1Button_Click(object sender, EventArgs e) => _presenter.ToggleRun(4);
+        private void ToggleRaceBox2Button_Click(object sender, EventArgs e) => _presenter.ToggleRun(5);
+        private void ToggleRaceBox3Button_Click(object sender, EventArgs e) => _presenter.ToggleRun(6);
 
-        // Optional helper if you want to call “move one sample” directly somewhere else:
-        private void ShiftRunOneSample(int slot, int direction) // direction: -1 left, +1 right
+        // -- Castle delete --
+        private void DeleteRun1Button_Click(object sender, EventArgs e) => _presenter.DeleteRun(1);
+        private void DeleteRun2Button_Click(object sender, EventArgs e) => _presenter.DeleteRun(2);
+        private void DeleteRun3Button_Click(object sender, EventArgs e) => _presenter.DeleteRun(3);
+
+        // -- RaceBox delete --
+        private void DeleteRaceBox1Button_Click(object sender, EventArgs e) => _presenter.DeleteRun(4);
+        private void DeleteRaceBox2Button_Click(object sender, EventArgs e) => _presenter.DeleteRun(5);
+        private void DeleteRaceBox3Button_Click(object sender, EventArgs e) => _presenter.DeleteRun(6);
+
+        // -- Castle shift --
+        private void ShiftLeftRun1_Click(object sender, EventArgs e) => _presenter.ApplyShiftDirection(1, -1, ModifierKeys);
+        private void ShiftRightRun1_Click(object sender, EventArgs e) => _presenter.ApplyShiftDirection(1, +1, ModifierKeys);
+        private void ShiftResetRun1_Click(object sender, EventArgs e) => _presenter.ResetShift(1);
+        private void ShiftLeftRun2_Click(object sender, EventArgs e) => _presenter.ApplyShiftDirection(2, -1, ModifierKeys);
+        private void ShiftRightRun2_Click(object sender, EventArgs e) => _presenter.ApplyShiftDirection(2, +1, ModifierKeys);
+        private void ShiftResetRun2_Click(object sender, EventArgs e) => _presenter.ResetShift(2);
+        private void ShiftLeftRun3_Click(object sender, EventArgs e) => _presenter.ApplyShiftDirection(3, -1, ModifierKeys);
+        private void ShiftRightRun3_Click(object sender, EventArgs e) => _presenter.ApplyShiftDirection(3, +1, ModifierKeys);
+        private void ShiftResetRun3_Click(object sender, EventArgs e) => _presenter.ResetShift(3);
+
+        // -- RaceBox shift (UI slot N maps to plot slot N+3) --
+        private void ShiftLeftRB1_Click(object sender, EventArgs e) => _presenter.ApplyShiftDirection(4, -1, ModifierKeys);
+        private void ShiftRightRB1_Click(object sender, EventArgs e) => _presenter.ApplyShiftDirection(4, +1, ModifierKeys);
+        private void ShiftResetRB1_Click(object sender, EventArgs e) => _presenter.ResetShift(4);
+        private void ShiftLeftRB2_Click(object sender, EventArgs e) => _presenter.ApplyShiftDirection(5, -1, ModifierKeys);
+        private void ShiftRightRB2_Click(object sender, EventArgs e) => _presenter.ApplyShiftDirection(5, +1, ModifierKeys);
+        private void ShiftResetRB2_Click(object sender, EventArgs e) => _presenter.ResetShift(5);
+        private void ShiftLeftRB3_Click(object sender, EventArgs e) => _presenter.ApplyShiftDirection(6, -1, ModifierKeys);
+        private void ShiftRightRB3_Click(object sender, EventArgs e) => _presenter.ApplyShiftDirection(6, +1, ModifierKeys);
+        private void ShiftResetRB3_Click(object sender, EventArgs e) => _presenter.ResetShift(6);
+
+        // -- Ellipsis-menu wrappers (Designer wires these via ConfigureMenu) --
+        private void miRun1Toggle_Click(object sender, EventArgs e) => _presenter.ToggleRun(1);
+        private void miRun1Remove_Click(object sender, EventArgs e) => _presenter.DeleteRun(1);
+        private void miRun1Reset_Click(object sender, EventArgs e) => _presenter.ResetShift(1);
+        private void miRun2Toggle_Click(object sender, EventArgs e) => _presenter.ToggleRun(2);
+        private void miRun2Remove_Click(object sender, EventArgs e) => _presenter.DeleteRun(2);
+        private void miRun2Reset_Click(object sender, EventArgs e) => _presenter.ResetShift(2);
+        private void miRun3Toggle_Click(object sender, EventArgs e) => _presenter.ToggleRun(3);
+        private void miRun3Remove_Click(object sender, EventArgs e) => _presenter.DeleteRun(3);
+        private void miRun3Reset_Click(object sender, EventArgs e) => _presenter.ResetShift(3);
+        private void miRB1Toggle_Click(object sender, EventArgs e) => _presenter.ToggleRun(4);
+        private void miRB1Remove_Click(object sender, EventArgs e) => _presenter.DeleteRun(4);
+        private void miRB1Reset_Click(object sender, EventArgs e) => _presenter.ResetShift(4);
+        private void miRB2Toggle_Click(object sender, EventArgs e) => _presenter.ToggleRun(5);
+        private void miRB2Remove_Click(object sender, EventArgs e) => _presenter.DeleteRun(5);
+        private void miRB2Reset_Click(object sender, EventArgs e) => _presenter.ResetShift(5);
+        private void miRB3Toggle_Click(object sender, EventArgs e) => _presenter.ToggleRun(6);
+        private void miRB3Remove_Click(object sender, EventArgs e) => _presenter.DeleteRun(6);
+        private void miRB3Reset_Click(object sender, EventArgs e) => _presenter.ResetShift(6);
+
+        // -- RunType pill click --
+        private void RunTypeSwitch_Click(object sender, EventArgs e) => _presenter.ToggleSpeedRunMode();
+
+        // =====================================================================
+        // RunType pill visuals + per-slot button enable plumbing
+        //   (Touches Designer-named controls — stays in the view.)
+        // =====================================================================
+
+        // RunType colors
+        private readonly Color _rtBaseBg = Color.FromArgb(235, 235, 235);
+
+        private void SyncRunTypeUI(bool isSpeedRun, bool locked)
         {
-            if (!_plotManager.Runs.TryGetValue(slot, out var run) || run is null)
-                return;
-
-            double stepSec = _plotManager.GetSampleStepSeconds(slot);
-            int stepMs = (int)Math.Round(stepSec * 1000.0);
-            run.TimeShiftMs += direction * stepMs;
-
-            _plotManager.PlotRuns(_plotManager.Runs.ToDictionary(k => k.Key, v => v.Value));
-        }
-
-        // ================================
-        // Ellipsis menu handlers (Run 1)
-        // ================================
-        private void miRun1Toggle_Click(object sender, EventArgs e) => ToggleRun1Button_Click(sender, e);
-        private void miRun1Remove_Click(object sender, EventArgs e) => DeleteRun1Button_Click(sender, e);
-        private void miRun1Reset_Click(object sender, EventArgs e) => ShiftResetRun1_Click(sender, e);
-
-        // ================================
-        // Ellipsis menu handlers (RaceBox 1)
-        // ================================
-        private void miRB1Toggle_Click(object sender, EventArgs e) => ToggleRaceBox1Button_Click(sender, e);
-        private void miRB1Remove_Click(object sender, EventArgs e) => DeleteRaceBox1Button_Click(sender, e);
-        private void miRB1Reset_Click(object sender, EventArgs e) => ShiftResetRB1_Click(sender, e);
-
-        // ================================
-        // Ellipsis menu handlers (Run 2)
-        // ================================
-        private void miRun2Toggle_Click(object sender, EventArgs e) => ToggleRun2Button_Click(sender, e);
-        private void miRun2Remove_Click(object sender, EventArgs e) => DeleteRun2Button_Click(sender, e);
-        private void miRun2Reset_Click(object sender, EventArgs e) => ShiftResetRun2_Click(sender, e);
-
-        // ================================
-        // Ellipsis menu handlers (RaceBox 2)
-        // ================================
-        private void miRB2Toggle_Click(object sender, EventArgs e) => ToggleRaceBox2Button_Click(sender, e);
-        private void miRB2Remove_Click(object sender, EventArgs e) => DeleteRaceBox2Button_Click(sender, e);
-        private void miRB2Reset_Click(object sender, EventArgs e) => ShiftResetRB2_Click(sender, e);
-
-        // ================================
-        // Ellipsis menu handlers (Run 3)
-        // ================================
-        private void miRun3Toggle_Click(object sender, EventArgs e) => ToggleRun3Button_Click(sender, e);
-        private void miRun3Remove_Click(object sender, EventArgs e) => DeleteRun3Button_Click(sender, e);
-        private void miRun3Reset_Click(object sender, EventArgs e) => ShiftResetRun3_Click(sender, e);
-
-        // ================================
-        // Ellipsis menu handlers (RaceBox 3)
-        // ================================
-        private void miRB3Toggle_Click(object sender, EventArgs e) => ToggleRaceBox3Button_Click(sender, e);
-        private void miRB3Remove_Click(object sender, EventArgs e) => DeleteRaceBox3Button_Click(sender, e);
-        private void miRB3Reset_Click(object sender, EventArgs e) => ShiftResetRB3_Click(sender, e);
-
-        // ================================
-        // Run Type UI (Drag vs Speed) — Compact Pill Switch
-        // ================================
-        #region RunType
-
-        // Keep this single source of truth:
-        private bool _isSpeedRunMode = false; // false=Drag, true=Speed
-                                              // --- RunType colors ---
-        private readonly Color _rtActiveFg = Color.FromArgb(35, 35, 35);      // near-black
-        private readonly Color _rtInactiveFg = Color.FromArgb(140, 140, 140);   // grey
-        private readonly Color _rtActiveBg = Color.FromArgb(225, 235, 255);   // light tint behind active
-        private readonly Color _rtBaseBg = Color.FromArgb(235, 235, 235);   // pill base background
-
-        private bool IsAnyRunLoaded() => _runs.Count > 0;
-
-        /// <summary>Position/paint the pill and (re)apply layout.</summary>
-        private void SyncRunTypeUI()
-        {
-            // slide knob (0 for Drag, 54 for Speed)
             if (runTypeKnob != null)
-                runTypeKnob.Left = _isSpeedRunMode ? 54 : 0;
+                runTypeKnob.Left = isSpeedRun ? 54 : 0;
 
-            // container background (neutral)
             if (runTypeSwitch != null)
                 runTypeSwitch.BackColor = _rtBaseBg;
 
-            // active vs inactive styling
-            // active vs inactive styling (active = black/bold, inactive = grey/regular)
-            bool speed = _isSpeedRunMode;
             var activeFg = Color.FromArgb(35, 35, 35);
             var inactiveFg = Color.FromArgb(140, 140, 140);
 
             if (runTypeDrag != null)
             {
-                runTypeDrag.ForeColor = speed ? inactiveFg : activeFg;
-                runTypeDrag.Font = new Font(runTypeDrag.Font, speed ? FontStyle.Regular : FontStyle.Bold);
+                runTypeDrag.ForeColor = isSpeedRun ? inactiveFg : activeFg;
+                runTypeDrag.Font = new Font(runTypeDrag.Font, isSpeedRun ? FontStyle.Regular : FontStyle.Bold);
             }
-
             if (runTypeSpeed != null)
             {
-                runTypeSpeed.ForeColor = speed ? activeFg : inactiveFg;
-                runTypeSpeed.Font = new Font(runTypeSpeed.Font, speed ? FontStyle.Bold : FontStyle.Regular);
+                runTypeSpeed.ForeColor = isSpeedRun ? activeFg : inactiveFg;
+                runTypeSpeed.Font = new Font(runTypeSpeed.Font, isSpeedRun ? FontStyle.Bold : FontStyle.Regular);
             }
 
-
-            // lock when any run is loaded
-            bool locked = IsAnyRunLoaded();
             if (runTypeSwitch != null)
                 runTypeSwitch.Enabled = !locked;
 
-            string tip = locked
-                ? "Clear all loaded logs to change mode."
-                : "Drag | Speed";
-
+            string tip = locked ? "Clear all loaded logs to change mode." : "Drag | Speed";
             var tt = new ToolTip(this.components);
             if (runTypeSwitch != null) tt.SetToolTip(runTypeSwitch, tip);
             if (runTypeKnob != null) tt.SetToolTip(runTypeKnob, tip);
             if (runTypeDrag != null) tt.SetToolTip(runTypeDrag, "Drag");
             if (runTypeSpeed != null) tt.SetToolTip(runTypeSpeed, "Speed");
 
-            // keep your existing visibility rules
-            ApplyRunTypeUI();
+            ApplyRunTypeUI(isSpeedRun);
         }
 
-
-        /// <summary>
-        /// Classic map:
-        /// - Speed: hide ALL RaceBox rows (1–3) + Castle Run 3 row
-        /// - Drag:  show everything
-        /// </summary>
-        private void ApplyRunTypeUI()
+        /// <summary>Speed mode hides all RaceBox rows + Castle Run 3.</summary>
+        public void ApplyRunTypeUI(bool isSpeedRun)
         {
-            bool isSpeedRun = _isSpeedRunMode;
-
             // RaceBox 1
             btnLoadRaceBox1.Visible = !isSpeedRun;
             btnShiftLeftRB1.Visible = !isSpeedRun;
@@ -1175,31 +390,67 @@ namespace CastleOverlayV2
             topButtonPanel?.Refresh();
         }
 
-        private void UpdateRunTypeLockState()
+        private void DisableAllSlotButtons()
         {
-            // keep current lock behaviour; just call Sync to reflect enable/tooltip
-            SyncRunTypeUI();
+            btnToggleRun1.Enabled = false;
+            btnDeleteRun1.Enabled = false;
+            btnToggleRun2.Enabled = false;
+            btnDeleteRun2.Enabled = false;
+            btnToggleRun3.Enabled = false;
+            btnDeleteRun3.Enabled = false;
+
+            btnToggleRaceBox1.Enabled = false;
+            btnDeleteRaceBox1.Enabled = false;
+            btnToggleRaceBox2.Enabled = false;
+            btnDeleteRaceBox2.Enabled = false;
+            btnToggleRaceBox3.Enabled = false;
+            btnDeleteRaceBox3.Enabled = false;
         }
 
-        // Click anywhere on the pill toggles mode (unless locked)
-        private void RunTypeSwitch_Click(object sender, EventArgs e)
+        private void SetSlotShiftButtonsEnabled(int uiSlot, bool enabled, bool isRaceBox)
         {
-            _isSpeedRunMode = !_isSpeedRunMode;
-
-            ApplyRunTypeUI();
-            UpdateRunTypeLockState();
-
-            PlotAllRuns();
-            _plotManager.SetSpeedMode(_isSpeedRunMode);
-            _plotManager.SetupAllAxes();
-
-            _plotManager.RefreshPlot();
+            if (!isRaceBox)
+            {
+                switch (uiSlot)
+                {
+                    case 1:
+                        btnShiftLeftRun1.Enabled = enabled;
+                        btnShiftRightRun1.Enabled = enabled;
+                        btnShiftResetRun1.Enabled = enabled;
+                        break;
+                    case 2:
+                        btnShiftLeftRun2.Enabled = enabled;
+                        btnShiftRightRun2.Enabled = enabled;
+                        btnShiftResetRun2.Enabled = enabled;
+                        break;
+                    case 3:
+                        btnShiftLeftRun3.Enabled = enabled;
+                        btnShiftRightRun3.Enabled = enabled;
+                        btnShiftResetRun3.Enabled = enabled;
+                        break;
+                }
+            }
+            else
+            {
+                switch (uiSlot)
+                {
+                    case 1:
+                        btnShiftLeftRB1.Enabled = enabled;
+                        btnShiftRightRB1.Enabled = enabled;
+                        btnShiftResetRB1.Enabled = enabled;
+                        break;
+                    case 2:
+                        btnShiftLeftRB2.Enabled = enabled;
+                        btnShiftRightRB2.Enabled = enabled;
+                        btnShiftResetRB2.Enabled = enabled;
+                        break;
+                    case 3:
+                        btnShiftLeftRB3.Enabled = enabled;
+                        btnShiftRightRB3.Enabled = enabled;
+                        btnShiftResetRB3.Enabled = enabled;
+                        break;
+                }
+            }
         }
-
-
-
-        #endregion
-
-
     }
 }

--- a/src/CastleOverlayV2/MainFormPresenter.cs
+++ b/src/CastleOverlayV2/MainFormPresenter.cs
@@ -1,0 +1,333 @@
+// File: src/CastleOverlayV2/MainFormPresenter.cs
+using CastleOverlayV2.Controls;
+using CastleOverlayV2.Models;
+using CastleOverlayV2.Plot;
+using CastleOverlayV2.Services;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace CastleOverlayV2
+{
+    /// <summary>
+    /// Owns run-slot state, file loading, plotting orchestration, and RunType mode.
+    /// MainForm is the view: it forwards events here and exposes the UI setters this class calls.
+    /// </summary>
+    public class MainFormPresenter
+    {
+        private readonly MainForm _view;
+        private readonly ConfigService _config;
+        private readonly PlotManager _plot;
+        private readonly ChannelToggleBar _toggleBar;
+
+        // Active runs by slot. Castle = 1..3, RaceBox = 4..6.
+        private readonly Dictionary<int, RunData> _runs = new();
+
+        // RaceBox header metadata per UI slot (1..3).
+        private RaceBoxData? _raceBox1, _raceBox2, _raceBox3;
+
+        private bool _isFourPoleMode;
+        private bool _isSpeedRunMode;
+
+        // Modifier-key shift step sizes (ms).
+        private const double SHIFT_FINE_MS = 1;     // Ctrl
+        private const double SHIFT_COARSE_MS = 1000; // Shift
+
+        public bool IsSpeedRunMode => _isSpeedRunMode;
+        public bool IsAnyRunLoaded => _runs.Count > 0;
+
+        public MainFormPresenter(MainForm view, ConfigService config, PlotManager plot, ChannelToggleBar toggleBar)
+        {
+            _view = view;
+            _config = config;
+            _plot = plot;
+            _toggleBar = toggleBar;
+
+            _isFourPoleMode = _config.Config.IsFourPoleMode;
+            _plot.SetFourPoleMode(_isFourPoleMode);
+            _plot.SetSpeedMode(_isSpeedRunMode);
+
+            _toggleBar.ChannelVisibilityChanged += OnChannelVisibilityChanged;
+            _toggleBar.RpmModeChanged += OnRpmModeChanged;
+            _plot.CursorMoved += OnCursorMoved;
+        }
+
+        // ============================================================
+        // Castle load
+        // ============================================================
+        public async Task LoadCastleRunAsync(int slot)
+        {
+            Logger.Log($"LoadCastleRunAsync({slot}) started");
+
+            string? path = _view.PickCsvFile();
+            if (path == null) return;
+
+            try
+            {
+                var loader = new CsvLoader(_config);
+                var loaded = await Task.Run(() => loader.Load(path, trimForDrag: !_isSpeedRunMode));
+
+                if (loaded != null && loaded.DataPoints.Count > 0)
+                {
+                    _runs[slot] = loaded;
+                    Logger.Log($"Loaded Run {slot} - {Path.GetFileName(path)} - {loaded.DataPoints.Count} rows");
+
+                    _plot.SetRun(slot, loaded);
+                    _plot.SetRunVisibility(slot, true);
+
+                    PlotAllRuns();
+                    _plot.SetSpeedMode(_isSpeedRunMode);
+                    _plot.SetupAllAxes();
+                    _plot.RefreshPlot();
+
+                    _view.SetSlotLoadedUI(slot, $"Run {slot}: {Path.GetFileName(path)}", _plot.GetRunVisibility(slot));
+                }
+                else
+                {
+                    _runs.Remove(slot);
+                    Logger.Log($"Run {slot} load failed or empty data.");
+                    _view.ShowError("Import Failed",
+                        "This file could not be loaded.\n\nIt may not be a valid Castle log or it contains no data.");
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"ERROR in Run{slot}: {ex.Message}");
+                _view.ShowError("Error", "An error occurred while loading the file.\n\n" + ex.Message);
+            }
+
+            _view.UpdateRunTypeLockState();
+        }
+
+        // ============================================================
+        // RaceBox load
+        // ============================================================
+        public async Task LoadRaceBoxRunAsync(int uiSlot)
+        {
+            int plotSlot = uiSlot + 3;
+            Logger.Log($"LoadRaceBoxRunAsync(UI {uiSlot} → plot slot {plotSlot}) started");
+
+            string? path = _view.PickCsvFile();
+            if (path == null) return;
+
+            try
+            {
+                var rbData = RaceBoxLoader.LoadHeaderOnly(path);
+                if (rbData == null)
+                {
+                    Logger.Log($"[Presenter] RaceBox header load failed for slot {uiSlot}.");
+                    return;
+                }
+
+                if (rbData.FirstCompleteRunIndex == null)
+                {
+                    _view.ShowInfo("Incomplete Run", "No complete run found in this RaceBox file.");
+                    return;
+                }
+
+                var loader = new RaceBoxLoader();
+                var points = await Task.Run(() => loader.LoadTelemetry(path, rbData.FirstCompleteRunIndex.Value));
+
+                if (points == null || points.Count == 0)
+                {
+                    Logger.Log($"[Presenter] RaceBox telemetry empty for slot {uiSlot}.");
+                    _view.ShowError("Telemetry Error",
+                        "RaceBox telemetry is empty or could not be parsed.");
+                    return;
+                }
+
+                switch (uiSlot)
+                {
+                    case 1: _raceBox1 = rbData; break;
+                    case 2: _raceBox2 = rbData; break;
+                    case 3: _raceBox3 = rbData; break;
+                }
+
+                var run = new RunData
+                {
+                    IsRaceBox = true,
+                    SplitTimes = rbData.SplitTimes,
+                    SplitLabels = rbData.SplitLabels,
+                    FileName = Path.GetFileName(path)
+                };
+                run.Data["RaceBox Speed"] = points
+                    .Select(p => new DataPoint { Time = p.Time.TotalSeconds, Y = p.SpeedMph })
+                    .ToList();
+                run.Data["RaceBox G-Force X"] = points
+                    .Select(p => new DataPoint { Time = p.Time.TotalSeconds, Y = p.GForceX })
+                    .ToList();
+                // PlotManager skips runs with empty DataPoints — populate with time-only dummies.
+                run.DataPoints = points
+                    .Select(p => new DataPoint { Time = p.Time.TotalSeconds })
+                    .ToList();
+
+                _runs[plotSlot] = run;
+                _plot.SetRun(plotSlot, run);
+                _plot.SetRunVisibility(plotSlot, true);
+
+                EnsureRaceBoxChannelsInToggleBar();
+                PlotAllRuns();
+
+                _view.SetSlotLoadedUI(plotSlot, $"RaceBox {uiSlot}: {TruncateFileName(path)}", true);
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"ERROR in RaceBox{uiSlot}: {ex.Message}");
+                _view.ShowError("Error", "An error occurred while loading the file.\n\n" + ex.Message);
+            }
+
+            _view.UpdateRunTypeLockState();
+        }
+
+        private void EnsureRaceBoxChannelsInToggleBar()
+        {
+            bool added = false;
+            var states = _toggleBar.GetChannelStates();
+            if (!states.ContainsKey("RaceBox Speed"))
+            {
+                _toggleBar.AddChannel("RaceBox Speed", true);
+                added = true;
+            }
+            if (!states.ContainsKey("RaceBox G-Force X"))
+            {
+                _toggleBar.AddChannel("RaceBox G-Force X", true);
+                added = true;
+            }
+            if (added)
+            {
+                _toggleBar.PerformLayout();
+                _toggleBar.Refresh();
+            }
+        }
+
+        // ============================================================
+        // Per-slot operations
+        // ============================================================
+        public void ToggleRun(int slot)
+        {
+            bool nowVisible = _plot.ToggleRunVisibility(slot);
+            _view.SetSlotToggleText(slot, nowVisible);
+        }
+
+        public void DeleteRun(int slot)
+        {
+            _runs.Remove(slot);
+            _view.ResetSlotUI(slot);
+
+            if (_plot.GetRunVisibility(slot))
+                _plot.ToggleRunVisibility(slot);
+
+            _plot.PlotRuns(new Dictionary<int, RunData>(_runs));
+            _view.UpdateRunTypeLockState();
+        }
+
+        public void ApplyShiftDirection(int slot, int direction, Keys modifiers)
+        {
+            double delta = GetClickDeltaMs(slot, modifiers) * direction;
+            if (!_runs.TryGetValue(slot, out var run)) return;
+            run.TimeShiftMs += delta;
+            Logger.Log($"⏱️ Run {slot} shift {(delta >= 0 ? "+" : "")}{delta} ms → total {run.TimeShiftMs} ms");
+            PlotAllRuns();
+        }
+
+        public void ResetShift(int slot)
+        {
+            if (!_runs.TryGetValue(slot, out var run)) return;
+            run.TimeShiftMs = 0;
+            Logger.Log($"⏱️ Run {slot} shift reset → 0 ms");
+            PlotAllRuns();
+        }
+
+        private double GetClickDeltaMs(int slot, Keys modifiers)
+        {
+            if ((modifiers & Keys.Control) == Keys.Control) return SHIFT_FINE_MS;
+            if ((modifiers & Keys.Shift) == Keys.Shift) return SHIFT_COARSE_MS;
+
+            double stepSec = _plot.GetSampleStepSeconds(slot);
+            if (stepSec <= 0) stepSec = 0.01;
+            return stepSec * 1000.0;
+        }
+
+        // ============================================================
+        // Mode toggle
+        // ============================================================
+        public void ToggleSpeedRunMode()
+        {
+            _isSpeedRunMode = !_isSpeedRunMode;
+            _view.ApplyRunTypeUI(_isSpeedRunMode);
+            _view.UpdateRunTypeLockState();
+
+            PlotAllRuns();
+            _plot.SetSpeedMode(_isSpeedRunMode);
+            _plot.SetupAllAxes();
+            _plot.RefreshPlot();
+        }
+
+        // ============================================================
+        // Event handlers (subscribed in ctor)
+        // ============================================================
+        private void OnChannelVisibilityChanged(string channelName, bool isVisible)
+        {
+            Logger.Log($"📎 Channel toggle: {channelName} → {(isVisible ? "Show" : "Hide")}");
+
+            // SetChannelVisibility updates per-scatter IsVisible and refreshes; no full replot needed.
+            _plot.SetChannelVisibility(channelName, isVisible);
+            _config.SetChannelVisibility(channelName, isVisible);
+        }
+
+        private void OnRpmModeChanged(bool isFourPole)
+        {
+            _isFourPoleMode = isFourPole;
+            _plot.SetFourPoleMode(_isFourPoleMode);
+
+            // Replot all 6 slots — both Castle and RaceBox.
+            PlotAllRuns();
+
+            _config.SetRpmMode(isFourPole);
+        }
+
+        private void OnCursorMoved(Dictionary<string, double?[]> valuesAtCursor)
+        {
+            _toggleBar.UpdateMousePositionValues(valuesAtCursor);
+        }
+
+        // ============================================================
+        // Plotting
+        // ============================================================
+        private void PlotAllRuns()
+        {
+            if (Logger.IsEnabled)
+            {
+                Logger.Log("PlotAllRuns called with runs:");
+                foreach (var (slot, run) in _runs)
+                    Logger.Log($"  Run {slot}: {run.DataPoints.Count} points, shift={run.TimeShiftMs} ms");
+            }
+
+            var visibilityMap = _toggleBar.GetChannelStates();
+
+            if (Logger.IsEnabled)
+            {
+                Logger.Log("PlotAllRuns — Channel visibility map before applying:");
+                foreach (var kvp in visibilityMap)
+                    Logger.Log($"  Channel: {kvp.Key}, Visible: {kvp.Value}");
+            }
+
+            _plot.SetInitialChannelVisibility(visibilityMap);
+            _plot.PlotRuns(new Dictionary<int, RunData>(_runs));
+        }
+
+        // ============================================================
+        // Helpers
+        // ============================================================
+        private static string TruncateFileName(string filePath, int maxChars = 28)
+        {
+            string fileName = Path.GetFileName(filePath) ?? string.Empty;
+            if (fileName.Length <= maxChars) return fileName;
+            if (maxChars <= 3) return fileName.Substring(0, maxChars);
+            return fileName.Substring(0, maxChars - 3) + "...";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Closes #57. Moves all business logic out of `MainForm.cs` into a new `MainFormPresenter` class.

| File | Before | After | Δ |
|---|---|---|---|
| `MainForm.cs` | 1205 lines | 456 lines | **−62%** |
| `MainFormPresenter.cs` | — | 333 lines | (new) |
| **Total** | 1205 | 789 | **−416 lines** |

## What moved into the Presenter
**State:** `_runs` dictionary, `_raceBox1/2/3` metadata, `_isFourPoleMode`, `_isSpeedRunMode`.

**Public API (called from `MainForm`'s event forwarders):**
- `LoadCastleRunAsync(int slot)`, `LoadRaceBoxRunAsync(int uiSlot)`
- `ToggleRun(int slot)`, `DeleteRun(int slot)`
- `ApplyShiftDirection(int slot, int direction, Keys modifiers)`, `ResetShift(int slot)`
- `ToggleSpeedRunMode()`
- `IsAnyRunLoaded`, `IsSpeedRunMode` (props)

**Subscribed in Presenter ctor:**
- `_channelToggleBar.ChannelVisibilityChanged`
- `_channelToggleBar.RpmModeChanged`
- `_plotManager.CursorMoved`

## What stays in `MainForm.cs`
- Constructor — wires up services, plot, toggle bar, presenter. Same call order as before.
- ~25 Designer-wired event handlers, now all **1-line forwarders** (`=> _presenter.LoadCastleRunAsync(1)` etc.).
- 6 public view methods the Presenter calls: `PickCsvFile`, `ShowError`, `ShowInfo`, `SetSlotLoadedUI`, `ResetSlotUI`, `SetSlotToggleText`, `UpdateRunTypeLockState`.
- RunType pill visuals (`SyncRunTypeUI`, `ApplyRunTypeUI`) — they touch Designer-named controls so they live with the view.
- Per-slot button enable plumbing — same reason.

## Why MainForm isn't sub-200 lines
The issue mentioned a target of <200 lines. The 256 lines above the floor come from:
- ~60 lines of Designer-wired 1-liner handlers (one per button — can't be parameterised without changing Designer wiring).
- ~180 lines of per-slot button-state switches in `SetSlotLoadedUI` / `ResetSlotUI` / `SetSlotShiftButtonsEnabled` (Designer-named controls can't be indexed).

Getting below that would require either reflection or a hand-built `Dictionary<int, SlotButtons>` lookup in the ctor — a meaningful chunk of additional code in `MainForm`. I think the current landing is the right trade-off: zero logic in the form, all UI mutation is mechanical.

## Behaviour
No intended changes. Same operations through the ctor; same calls per click; same `PlotManager` interactions in the same order.

## Build / tests
\`\`\`
Build: 0 errors. Warnings 69 → 54 (deleted Logger calls).
Passed!  - Failed: 0, Passed: 28, Skipped: 0, Total: 28
\`\`\`

## Test plan — please go through everything
This is the biggest single refactor in the session. Build is clean and existing tests pass, but `MainForm` is essentially un-unit-tested. Try:

- [ ] App opens. Title shows build number. Empty-plot message visible.
- [ ] Drag mode (default): all 3 Castle and 3 RaceBox slot buttons visible.
- [ ] Load Castle Run 1 → Run 2 → Run 3 in order. Each plots; toggle bar shows hover values; existing runs stay.
- [ ] Load RaceBox 1, 2, 3. Split lines appear; correct colors; toggle bar adds the RaceBox channels on first load.
- [ ] Toggle a channel off → hidden in plot. Toggle on → visible. State persists across restart (config.json).
- [ ] Toggle 2P ↔ 4P with all 6 slots loaded → **all 6 stay plotted** (the bug from #46 must remain fixed).
- [ ] Hide / Show buttons per slot work. Text flips correctly.
- [ ] Shift Left / Right / Reset on each of the 6 slots — only that slot moves. Ctrl = fine step. Shift = coarse step. No modifier = one sample step.
- [ ] Delete a Castle slot → buttons reset, label back to "Load Run N", remaining slots untouched.
- [ ] Delete a RaceBox slot → same.
- [ ] Delete all 6 → empty-plot message returns. Load again from cold → works.
- [ ] Switch to Speed mode (only available with all slots empty) → RaceBox UI and Castle Run 3 hide. Switch back → all visible.
- [ ] Ellipsis menus on each slot still open and Hide/Delete/Reset Shift inside them still work (Designer wires these via `ConfigureMenu`; they're 1-liner forwarders too).

## Workflow
Per repo `CLAUDE.md`: yours to merge — I will not run `gh pr merge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)