### PR TITLE
ui phase 1: dark theme, palette, focus model, no markers (closes #72)

### DIFF
--- a/src/CastleOverlayV2/Controls/ChannelToggleBar.cs
+++ b/src/CastleOverlayV2/Controls/ChannelToggleBar.cs
@@ -24,6 +24,10 @@ namespace CastleOverlayV2.Controls
             AutoSize = true;
             AutoSizeMode = AutoSizeMode.GrowAndShrink;
 
+            // Phase 1 dark theme — surface.panel + text.primary.
+            BackColor = Color.FromArgb(0x16, 0x1B, 0x23);
+            ForeColor = Color.FromArgb(0xE6, 0xE9, 0xEF);
+
             BuildLayout(channelNames, initialStates);
         }
 

--- a/src/CastleOverlayV2/MainForm.cs
+++ b/src/CastleOverlayV2/MainForm.cs
@@ -26,6 +26,12 @@ namespace CastleOverlayV2
 
             InitializeComponent();
 
+            // Dark theme — surface.window (chrome around the plot).
+            // Phase 1 minimum: form + plot are dark; the run strip / drawer get full
+            // theme treatment in their own phases.
+            this.BackColor = Color.FromArgb(0x13, 0x17, 0x1E);
+            this.ForeColor = Color.FromArgb(0xE6, 0xE9, 0xEF);
+
             // App icon + title
             var iconStream = Assembly.GetExecutingAssembly()
                 .GetManifestResourceStream("CastleOverlayV2.Resources.DragOverlay.ico");

--- a/src/CastleOverlayV2/Plot/PlotManager.cs
+++ b/src/CastleOverlayV2/Plot/PlotManager.cs
@@ -36,6 +36,20 @@ namespace CastleOverlayV2.Plot
         // Lazy cache of channel → scatters, rebuilt on demand after _scatters mutates.
         private Dictionary<string, List<Scatter>>? _channelToScattersCache;
 
+        // Phase 1 focus model: one channel is "focused" (full opacity, owns the visible left Y axis);
+        // all other visible channels render as dim context traces. Focus is hardcoded to RPM
+        // for now — Phase 3 (#74) makes it interactive.
+        private string _focusedChannel = "RPM";
+
+        // Dark theme tokens (from Docs/DragOverlay_UI_Spec.md §5).
+        private static readonly ScottPlot.Color ThemePlotBg = new(0x0E, 0x12, 0x18);   // surface.plot
+        private static readonly ScottPlot.Color ThemeWindow = new(0x13, 0x17, 0x1E);   // surface.window
+        private static readonly ScottPlot.Color ThemeText = new(0xE6, 0xE9, 0xEF);     // text.primary
+        private static readonly ScottPlot.Color ThemeTextDim = new(0x9A, 0xA3, 0xB2);  // text.secondary
+        private static readonly ScottPlot.Color ThemeGrid = new(0xFF, 0xFF, 0xFF, 13); // border.grid (~0.05 alpha)
+        private static readonly ScottPlot.Color ThemeSplit = new(0x7C, 0x5A, 0x2E);    // split markers (66 / 132 ft)
+        private const byte ContextAlpha = 71; // 0.28 × 255
+
         // Visibility & storage
         private readonly Dictionary<int, bool> _runVisibility = new();
         private Dictionary<string, bool> _channelVisibility = new();
@@ -134,6 +148,10 @@ namespace CastleOverlayV2.Plot
             _plot = plotControl ?? throw new ArgumentNullException(nameof(plotControl));
             _plot.Plot.Clear();
 
+            // Dark theme — figure + data backgrounds
+            _plot.Plot.FigureBackground.Color = ThemeWindow;
+            _plot.Plot.DataBackground.Color = ThemePlotBg;
+
             // Title & legend
             _plot.Plot.Title(null);
             _plot.Plot.Legend.IsVisible = false;
@@ -143,22 +161,45 @@ namespace CastleOverlayV2.Plot
 
             _plot.Refresh();
 
-
-            // X axis label
+            // X axis label (dark theme: secondary text colour)
             var x = _plot.Plot.Axes.Bottom;
             x.Label.Text = "Time (s)";
             x.Label.FontSize = 12;
+            ApplyDarkAxisStyle(x, ThemeTextDim);
 
-            // Grid style (vertical only)
+            // Grid style (vertical only, low-alpha for dark theme)
             _plot.Plot.Grid.XAxisStyle.IsVisible = true;
             _plot.Plot.Grid.YAxisStyle.IsVisible = false;
-            _plot.Plot.Grid.MajorLineColor = ScottPlot.Colors.Grey.WithAlpha(75);
-            _plot.Plot.Grid.MinorLineColor = ScottPlot.Colors.Grey.WithAlpha(25);
-            _plot.Plot.Grid.MajorLineWidth = 2;
+            _plot.Plot.Grid.MajorLineColor = ThemeGrid;
+            _plot.Plot.Grid.MinorLineColor = ThemeGrid;
+            _plot.Plot.Grid.MajorLineWidth = 1;
             _plot.Plot.Grid.MinorLineWidth = 1;
 
             _plot.MouseMove += FormsPlot_MouseMove;
             _plot.Refresh();
+        }
+
+        /// <summary>
+        /// Set tick + label + frame colours on an axis to a single dark-theme tint.
+        /// </summary>
+        private static void ApplyDarkAxisStyle(IAxis axis, ScottPlot.Color color)
+        {
+            axis.Label.ForeColor = color;
+            axis.TickLabelStyle.ForeColor = color;
+            axis.MajorTickStyle.Color = color;
+            axis.MinorTickStyle.Color = color;
+            axis.FrameLineStyle.Color = color;
+        }
+
+        /// <summary>
+        /// Channel hue, dimmed to <see cref="ContextAlpha"/> when this channel is not the focused one.
+        /// </summary>
+        private ScottPlot.Color GetTraceColor(string channelLabel)
+        {
+            var baseColor = ChannelColorMap.GetColor(channelLabel);
+            return channelLabel == _focusedChannel
+                ? baseColor
+                : baseColor.WithAlpha(ContextAlpha);
         }
 
         // ---------------- Public API ----------------
@@ -341,9 +382,10 @@ namespace CastleOverlayV2.Plot
 
                     var s = _plot.Plot.Add.Scatter(xs, ysToPlot);
                     s.Label = channelLabel;
-                    s.Color = ChannelColorMap.GetColor(channelLabel);
+                    s.Color = GetTraceColor(channelLabel);
                     s.LinePattern = LineStyleHelper.GetLinePattern(slot - 1);
                     s.LineWidth = (float)LineStyleHelper.GetLineWidth(slot - 1);
+                    s.MarkerSize = 0; // line-only — markers are noise (spec §6.3)
                     s.Axes.XAxis = xAxis;
                     s.Axes.YAxis = channelLabel switch
                     {
@@ -514,9 +556,58 @@ namespace CastleOverlayV2.Plot
                 HideAxis(raceBoxGxAxis);
             }
 
+            // Show the focused channel's axis with its hue; keep the rest hidden.
+            ApplyFocusToAxes();
+
             // NOTE: Do NOT call AddLeftAxis/AddRightAxis again after this point.
             // Lock add/remove lives in ReapplyAxisLocks (single source of truth).
         }
+
+        /// <summary>
+        /// Make the focused channel's Y axis visible in its hue; every other Castle/RaceBox
+        /// Y axis stays hidden. Called after axis creation and on every replot.
+        /// </summary>
+        private void ApplyFocusToAxes()
+        {
+            // Hide all known axes first.
+            foreach (var axis in new IAxis?[] {
+                throttleAxis, rpmAxis, voltageAxis, currentAxis, rippleAxis, powerAxis,
+                escTempAxis, motorTempAxis, motorTimingAxis, accelAxis,
+                raceBoxSpeedAxis, raceBoxGxAxis })
+            {
+                if (axis is not null) HideAxis(axis);
+            }
+
+            // Show the focused channel's axis with its hue.
+            var focusAxis = AxisFor(_focusedChannel);
+            if (focusAxis is not null)
+            {
+                var hue = ChannelColorMap.GetColor(_focusedChannel);
+                focusAxis.Label.IsVisible = true;
+                focusAxis.TickLabelStyle.IsVisible = true;
+                focusAxis.MajorTickStyle.Length = 5;
+                focusAxis.MinorTickStyle.Length = 3;
+                focusAxis.FrameLineStyle.Width = 1;
+                ApplyDarkAxisStyle(focusAxis, hue);
+            }
+        }
+
+        private IAxis? AxisFor(string channelLabel) => channelLabel switch
+        {
+            "RPM" => rpmAxis,
+            "Throttle %" => throttleAxis,
+            "Voltage" => voltageAxis,
+            "Current" => currentAxis,
+            "Ripple" => rippleAxis,
+            "PowerOut" => powerAxis,
+            "ESC Temp" => escTempAxis,
+            "MotorTemp" => motorTempAxis,
+            "MotorTiming" => motorTimingAxis,
+            "Acceleration" => accelAxis,
+            "RaceBox Speed" => raceBoxSpeedAxis,
+            "RaceBox G-Force X" => raceBoxGxAxis,
+            _ => null
+        };
 
 
         private void ReapplyAxisLocks()
@@ -651,9 +742,10 @@ namespace CastleOverlayV2.Plot
 
                 var s = _plot.Plot.Add.Scatter(xs, ys);
                 s.Label = ch;
-                s.Color = ChannelColorMap.GetColor(ch);
+                s.Color = GetTraceColor(ch);
                 s.LinePattern = LineStyleHelper.GetLinePattern(slot - 1);
                 s.LineWidth = (float)LineStyleHelper.GetLineWidth(slot - 1);
+                s.MarkerSize = 0; // line-only — markers are noise (spec §6.3)
                 s.Axes.XAxis = _plot.Plot.Axes.Bottom;
                 s.Axes.YAxis = ch == "RaceBox Speed" ? raceBoxSpeedAxis : raceBoxGxAxis;
 
@@ -685,13 +777,20 @@ namespace CastleOverlayV2.Plot
                 labels.Insert(0, "Start");
             }
 
+            // Dark-theme split markers (spec §5: 66/132 ft = #7C5A2E, finish = #9A3D2E).
+            // For Phase 1 use the 66/132 colour for all splits; the dedicated finish hue can
+            // come back once the label data flags which split is the finish.
+            var splitColor = ThemeSplit;
+            var labelBg = new ScottPlot.Color(0x1B, 0x21, 0x2B);   // surface.bar
+            var labelFg = ThemeText;
+
             var lines = new List<VerticalLine>();
             foreach (double t in times)
             {
                 var v = _plot.Plot.Add.VerticalLine(t);
                 v.LinePattern = LineStyleHelper.GetLinePattern(99);
-                v.LineWidth = 2;
-                v.Color = ScottPlot.Colors.DarkBlue.WithAlpha(200);
+                v.LineWidth = 1.5f;
+                v.Color = splitColor;
                 lines.Add(v);
             }
             _splitLinesBySlot[slot] = lines;
@@ -703,10 +802,10 @@ namespace CastleOverlayV2.Plot
                 var lbl = _plot.Plot.Add.Text(txt, times[i], 0.95);
                 lbl.Axes.YAxis = _splitLabelAxis!;
                 lbl.Alignment = Alignment.UpperCenter;
-                lbl.FontSize = 12;
-                lbl.FontColor = ScottPlot.Colors.DarkBlue;
-                lbl.BackgroundColor = ScottPlot.Colors.White.WithAlpha(180);
-                lbl.BorderColor = ScottPlot.Colors.DarkBlue;
+                lbl.FontSize = 11;
+                lbl.FontColor = labelFg;
+                lbl.BackgroundColor = labelBg;
+                lbl.BorderColor = splitColor;
                 lbl.BorderWidth = 1;
                 lbl.OffsetY = -2;
                 lbls.Add(lbl);
@@ -866,7 +965,7 @@ namespace CastleOverlayV2.Plot
             var msg = _plot.Plot.Add.Text("Waiting for log...", 0, 0);
             msg.Alignment = Alignment.MiddleCenter;
             msg.FontSize = 18;
-            msg.Color = ScottPlot.Colors.Gray;
+            msg.Color = ThemeTextDim;
 
             PixelPadding padding = new(left: 40, right: 40, top: 10, bottom: 50);
             _plot.Plot.Layout.Fixed(padding);

--- a/src/CastleOverlayV2/Utils/ColorMap.cs
+++ b/src/CastleOverlayV2/Utils/ColorMap.cs
@@ -2,30 +2,29 @@
 
 namespace CastleOverlayV2.Utils
 {
+    /// <summary>
+    /// Channel → trace color, dark-theme palette from <c>Docs/DragOverlay_UI_Spec.md</c> §5.
+    /// Channel hue is stable; focus state (handled in <see cref="Plot.PlotManager"/>) changes only opacity.
+    /// </summary>
     public static class ChannelColorMap
     {
         private static readonly Dictionary<string, ScottPlot.Color> ChannelColors = new()
         {
-            { "Voltage", new ScottPlot.Color(255, 0, 0) },         // #FF0000
-            { "Ripple", new ScottPlot.Color(128, 0, 128) },        // #800080
-            { "Current", new ScottPlot.Color(0, 128, 0) },         // #008000
-            { "PowerOut", new ScottPlot.Color(70, 130, 180) },     // #4682B4
-            { "MotorTemp", new ScottPlot.Color(147, 112, 219) },
-            { "RPM", new ScottPlot.Color(165, 42, 42) },           // #A52A2A
+            // Castle ESC channels
+            { "RPM", new ScottPlot.Color(0x4C, 0x9A, 0xED) },          // #4C9AED  blue
+            { "Throttle %", new ScottPlot.Color(0xEF, 0x9F, 0x27) },   // #EF9F27  amber
+            { "Current", new ScottPlot.Color(0x2B, 0xB4, 0x8A) },      // #2BB48A  teal
+            { "Voltage", new ScottPlot.Color(0xE0, 0x74, 0x4B) },      // #E0744B  coral
+            { "PowerOut", new ScottPlot.Color(0x7F, 0xB6, 0xF2) },     // #7FB6F2  light blue
+            { "Ripple", new ScottPlot.Color(0x97, 0xC4, 0x59) },       // #97C459  green
+            { "ESC Temp", new ScottPlot.Color(0xE2, 0x4B, 0x4A) },     // #E24B4A  red
+            { "MotorTemp", new ScottPlot.Color(0xBA, 0x75, 0x17) },    // #BA7517  deep amber
+            { "MotorTiming", new ScottPlot.Color(0xB4, 0xB2, 0xA9) },  // #B4B2A9  warm grey
+            { "Acceleration", new ScottPlot.Color(0xD8, 0x5A, 0x30) }, // #D85A30  dark coral
 
-            // Legacy Castle format (ms)
-            //{ "Throttle", new ScottPlot.Color(0, 0, 0) },          // #000000
-
-            // New percent-based channel
-            { "Throttle %", new ScottPlot.Color(0, 0, 0) },        // #000000
-
-            { "Acceleration", new ScottPlot.Color(65, 105, 225) }, // #4169E1
-            { "MotorTiming", new ScottPlot.Color(0, 0, 128) },     // #000080
-            { "ESC Temp", new ScottPlot.Color(255, 0, 250) },      // #FF00FA
-
-            // ✅ RaceBox channels
-            { "RaceBox Speed", new ScottPlot.Color(255, 140, 0) },   // #FF8C00
-            { "RaceBox G-Force X", new ScottPlot.Color(0, 206, 209) } // #00CED1
+            // RaceBox GPS channels
+            { "RaceBox Speed", new ScottPlot.Color(0xD4, 0x53, 0x7E) },     // #D4537E  pink
+            { "RaceBox G-Force X", new ScottPlot.Color(0x9F, 0x8F, 0xE0) }, // #9F8FE0  light purple
         };
 
         public static ScottPlot.Color GetColor(string channelName)
@@ -33,8 +32,8 @@ namespace CastleOverlayV2.Utils
             if (ChannelColors.TryGetValue(channelName, out var color))
                 return color;
 
-            // Fallback: neutral gray instead of exception
-            return new ScottPlot.Color(128, 128, 128);
+            // Fallback for any unmapped channel: text.secondary grey.
+            return new ScottPlot.Color(0x9A, 0xA3, 0xB2);
         }
     }
 }


### PR DESCRIPTION
## Summary
Closes #72. First slice of the UI redesign (umbrella #41, spec `Docs/DragOverlay_UI_Spec.md`).

This PR restyles the plot itself before any layout changes — the buttons and toggle bar stay where they are, but the data area is now dark with the new palette and a hardcoded RPM focus.

## Diff
4 files changed, +144 / −36.

| File | Change |
|---|---|
| `Utils/ColorMap.cs` | All 12 channel hues swapped to spec §5 palette. Fallback = text.secondary. |
| `Plot/PlotManager.cs` | Dark FigureBackground/DataBackground, dim grid, focused-axis logic, no markers, new split-marker colors, dark "Waiting for log…" text. |
| `MainForm.cs` | BackColor + ForeColor = surface.window / text.primary. |
| `Controls/ChannelToggleBar.cs` | BackColor + ForeColor = surface.panel / text.primary (this bar is replaced in Phase 2 anyway). |

## Focus model (hardcoded for this phase)
\`\`\`
_focusedChannel = "RPM"
\`\`\`
- Focused channel scatter: full opacity.
- Other visible channel scatters: same hue at **0.28 alpha** (71/255).
- RPM axis: tick labels + label + frame shown in the channel's blue.
- All other Y axes stay hidden.

`Phase 3 (#74)` makes the focused channel change on card-click.

## What stays the same
- Run identity is still line style (solid/dashed/dotted per slot via `LineStyleHelper`).
- Run visibility, channel visibility, hover values, split lines, X-only zoom locks — all unchanged.
- 6-slot model unchanged.

## What's deliberately out of scope (later phases)
- Top button panel still has default WinForms light grey buttons — replaced by the run strip in **Phase 4 (#75)**.
- Stat cards (Max/Avg/@cursor) — **Phase 2 (#73)**.
- Click-to-focus channel — **Phase 3 (#74)**.
- Drag-to-align — **Phase 6 (#77)**.

## Build / tests
\`\`\`
Build: 0 errors. Warnings 54 → 51.
Passed!  - Failed: 0, Passed: 28, Skipped: 0, Total: 28
\`\`\`

## Test plan — please look at this with real data
This is the first user-visible visual change. Please load some Castle + RaceBox logs and check:

- [ ] Plot data area is dark (`#0E1218`).
- [ ] Channel colors look like the spec mockup (RPM blue, Throttle amber, etc.) — they will look different from the old red/green/black palette.
- [ ] **Only RPM** has a visible Y axis with tick labels and a label. All other channels' Y axes are hidden.
- [ ] RPM trace is bright; all other visible channels are dim (a context wash).
- [ ] No per-point dots/markers on any line — just smooth lines.
- [ ] Split markers (when RaceBox splits load): brown vertical lines with small labels at the top.
- [ ] Hover values in the bottom bar still update correctly.
- [ ] Toggle a channel off → it disappears. Toggle on → it returns as a dim context trace (since it's not the focused channel).
- [ ] 2P / 4P toggle still works without losing RaceBox runs (regression check on #46).

## Accept criteria (from spec §12.1)
> App looks like the dark mockup with existing data loaded; one channel can be focused (even if focus is hard-coded initially).

## Workflow
Per repo `CLAUDE.md`: yours to merge — I will not run `gh pr merge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)