### PR TITLE
ui phase 3: click-card-to-focus channel (closes #74)

### DIFF
--- a/Tests/CastleOverlayV2.Tests/LineStyleHelperTests.cs
+++ b/Tests/CastleOverlayV2.Tests/LineStyleHelperTests.cs
@@ -5,19 +5,8 @@ namespace CastleOverlayV2.Tests;
 
 public class LineStyleHelperTests
 {
-    [Theory]
-    [InlineData(0, 2.5)] // Castle Run 1 — boldest
-    [InlineData(1, 1.5)] // Castle Run 2
-    [InlineData(2, 1.0)] // Castle Run 3 — thinnest
-    [InlineData(3, 2.0)] // RaceBox 1 — default
-    [InlineData(4, 2.0)] // RaceBox 2 — default
-    [InlineData(5, 2.0)] // RaceBox 3 — default
-    [InlineData(99, 2.0)] // Split lines — default
-    [InlineData(-1, 2.0)] // Out of range — default
-    public void GetLineWidth_returns_expected(int index, double expected)
-    {
-        Assert.Equal(expected, LineStyleHelper.GetLineWidth(index));
-    }
+    // Note: GetLineWidth was removed when Phase 3 (#74) made line width focus-based
+    // (set in PlotManager.WidthFor), not slot-based. Run identity is now line style only.
 
     [Theory]
     [InlineData(0, "Solid")]  // Castle Run 1

--- a/src/CastleOverlayV2/Controls/ChannelDrawer.cs
+++ b/src/CastleOverlayV2/Controls/ChannelDrawer.cs
@@ -20,20 +20,25 @@ namespace CastleOverlayV2.Controls
     public class ChannelDrawer : UserControl
     {
         // ---- Theme tokens (Spec §5) -----------------------------------------
-        private static readonly Color SurfacePanel = Color.FromArgb(0x16, 0x1B, 0x23);
-        private static readonly Color SurfaceBar   = Color.FromArgb(0x1B, 0x21, 0x2B);
-        private static readonly Color SurfaceCard  = Color.FromArgb(0x1A, 0x1F, 0x27);
-        private static readonly Color TextPrimary  = Color.FromArgb(0xE6, 0xE9, 0xEF);
-        private static readonly Color TextSecond   = Color.FromArgb(0x9A, 0xA3, 0xB2);
-        private static readonly Color TextDim      = Color.FromArgb(0x5C, 0x65, 0x73);
-        private static readonly Color BorderDef    = Color.FromArgb(0x29, 0x2F, 0x39);
+        private static readonly Color SurfacePanel    = Color.FromArgb(0x16, 0x1B, 0x23);
+        private static readonly Color SurfaceBar      = Color.FromArgb(0x1B, 0x21, 0x2B);
+        private static readonly Color SurfaceCard     = Color.FromArgb(0x1A, 0x1F, 0x27);
+        private static readonly Color SurfaceCardFocus= Color.FromArgb(0x17, 0x22, 0x30);
+        private static readonly Color TextPrimary     = Color.FromArgb(0xE6, 0xE9, 0xEF);
+        private static readonly Color TextAccent      = Color.FromArgb(0x9A, 0xC7, 0xF2);
+        private static readonly Color TextSecond      = Color.FromArgb(0x9A, 0xA3, 0xB2);
+        private static readonly Color TextDim         = Color.FromArgb(0x5C, 0x65, 0x73);
+        private static readonly Color BorderDef       = Color.FromArgb(0x29, 0x2F, 0x39);
+        private static readonly Color BorderFocus     = Color.FromArgb(0x2C, 0x5A, 0x86);
 
         // ---- Public surface (matches old ChannelToggleBar) ------------------
         public event Action<string, bool>? ChannelVisibilityChanged;
         public event Action<bool>? RpmModeChanged;
+        public event Action<string>? ChannelFocused;
 
         // ---- State ----------------------------------------------------------
         private bool _expanded = true;
+        private string _focusedChannel = "RPM"; // matches PlotManager's initial focus
         private readonly Dictionary<string, ChannelCard> _cards = new();
         private readonly Dictionary<string, ChannelDot> _dots = new();
 
@@ -129,8 +134,11 @@ namespace CastleOverlayV2.Controls
                 ChannelVisibilityChanged?.Invoke(n, v);
             };
             card.RpmModeToggled += isFourPole => RpmModeChanged?.Invoke(isFourPole);
+            card.Focused += n => ChannelFocused?.Invoke(n);
             _cards[channelName] = card;
             _cardFlow.Controls.Add(card);
+            if (channelName == _focusedChannel)
+                card.SetFocused(true);
 
             var dot = new ChannelDot(channelName, initialVisible);
             dot.Toggled += (n, v) =>
@@ -140,6 +148,21 @@ namespace CastleOverlayV2.Controls
             };
             _dots[channelName] = dot;
             _dotFlow.Controls.Add(dot);
+        }
+
+        /// <summary>
+        /// Mark <paramref name="channelName"/> as the focused card. Idempotent.
+        /// </summary>
+        public void SetFocusedChannel(string channelName)
+        {
+            if (_focusedChannel == channelName) return;
+            string previous = _focusedChannel;
+            _focusedChannel = channelName;
+
+            if (_cards.TryGetValue(previous, out var prev))
+                prev.SetFocused(false);
+            if (_cards.TryGetValue(channelName, out var next))
+                next.SetFocused(true);
         }
 
         public Dictionary<string, bool> GetChannelStates() =>
@@ -239,11 +262,14 @@ namespace CastleOverlayV2.Controls
         {
             public string ChannelName { get; }
             public bool IsChannelVisible { get; private set; }
+            public bool IsFocused { get; private set; }
 
             public event Action<string, bool>? VisibilityChanged;
             public event Action<bool>? RpmModeToggled;
+            public event Action<string>? Focused;
 
             private readonly TableLayoutPanel _layout;
+            private readonly Label _nameLbl;
             private readonly Button _eyeBtn;
             private readonly Button? _rpmModeBtn;
             private bool _isFourPole;
@@ -301,7 +327,7 @@ namespace CastleOverlayV2.Controls
                 };
                 header.Controls.Add(dot, 0, 0);
 
-                var nameLbl = new Label
+                _nameLbl = new Label
                 {
                     Text = channelName,
                     AutoSize = true,
@@ -309,7 +335,7 @@ namespace CastleOverlayV2.Controls
                     Font = new Font(SystemFonts.DefaultFont.FontFamily, 9.5f, FontStyle.Bold),
                     Margin = new Padding(2, 4, 0, 0)
                 };
-                header.Controls.Add(nameLbl, 1, 0);
+                header.Controls.Add(_nameLbl, 1, 0);
 
                 _eyeBtn = new Button
                 {
@@ -353,6 +379,21 @@ namespace CastleOverlayV2.Controls
 
                 Controls.Add(_layout);
                 UpdateEyeAppearance();
+
+                // Card body (and the name label) → click focuses this channel.
+                // The eye button and RPM-mode button keep their own click handlers
+                // (they do NOT propagate to the body click).
+                this.Click += (_, _) => Focused?.Invoke(ChannelName);
+                _nameLbl.Click += (_, _) => Focused?.Invoke(ChannelName);
+                _layout.Click += (_, _) => Focused?.Invoke(ChannelName);
+            }
+
+            public void SetFocused(bool focused)
+            {
+                if (IsFocused == focused) return;
+                IsFocused = focused;
+                BackColor = focused ? SurfaceCardFocus : SurfaceCard;
+                _nameLbl.ForeColor = focused ? TextAccent : TextPrimary;
             }
 
             public void SetVisible(bool visible)

--- a/src/CastleOverlayV2/MainFormPresenter.cs
+++ b/src/CastleOverlayV2/MainFormPresenter.cs
@@ -52,6 +52,7 @@ namespace CastleOverlayV2
 
             _drawer.ChannelVisibilityChanged += OnChannelVisibilityChanged;
             _drawer.RpmModeChanged += OnRpmModeChanged;
+            _drawer.ChannelFocused += OnChannelFocused;
             _plot.CursorMoved += OnCursorMoved;
         }
 
@@ -310,6 +311,14 @@ namespace CastleOverlayV2
             PlotAllRuns();
 
             _config.SetRpmMode(isFourPole);
+        }
+
+        private void OnChannelFocused(string channelName)
+        {
+            // Mirror the focus state to the plot (which re-tints + re-binds the visible Y axis)
+            // and back to the drawer (which highlights the focused card).
+            _plot.SetFocusedChannel(channelName);
+            _drawer.SetFocusedChannel(channelName);
         }
 
         private void OnCursorMoved(Dictionary<string, double?[]> valuesAtCursor)

--- a/src/CastleOverlayV2/Plot/PlotManager.cs
+++ b/src/CastleOverlayV2/Plot/PlotManager.cs
@@ -36,10 +36,14 @@ namespace CastleOverlayV2.Plot
         // Lazy cache of channel → scatters, rebuilt on demand after _scatters mutates.
         private Dictionary<string, List<Scatter>>? _channelToScattersCache;
 
-        // Phase 1 focus model: one channel is "focused" (full opacity, owns the visible left Y axis);
-        // all other visible channels render as dim context traces. Focus is hardcoded to RPM
-        // for now — Phase 3 (#74) makes it interactive.
+        // Focus model: one channel is "focused" (full opacity, normal line width, owns the
+        // visible left Y axis); every other visible channel renders as a dim context trace.
+        // Initial value is RPM; SetFocusedChannel(...) flips it on a card click (Phase 3).
         private string _focusedChannel = "RPM";
+
+        // Line widths per focus state (spec §6.3).
+        private const float FocusedLineWidth = 2.0f;
+        private const float ContextLineWidth = 1.3f;
 
         // Dark theme tokens (from Docs/DragOverlay_UI_Spec.md §5).
         private static readonly ScottPlot.Color ThemePlotBg = new(0x0E, 0x12, 0x18);   // surface.plot
@@ -191,6 +195,28 @@ namespace CastleOverlayV2.Plot
             axis.FrameLineStyle.Color = color;
         }
 
+        public string FocusedChannel => _focusedChannel;
+
+        /// <summary>
+        /// Change the focused channel. Re-tints every existing scatter (full opacity if it
+        /// matches the new focus, dimmed otherwise), re-binds the single visible Y axis to
+        /// the new channel, and triggers a refresh. No replot needed.
+        /// </summary>
+        public void SetFocusedChannel(string channelName)
+        {
+            if (_focusedChannel == channelName) return;
+            _focusedChannel = channelName;
+
+            foreach (var s in _scatters)
+            {
+                s.Color = GetTraceColor(s.Label);
+                s.LineWidth = WidthFor(s.Label);
+            }
+
+            ApplyFocusToAxes();
+            _plot.Refresh();
+        }
+
         /// <summary>
         /// Channel hue, dimmed to <see cref="ContextAlpha"/> when this channel is not the focused one.
         /// </summary>
@@ -201,6 +227,9 @@ namespace CastleOverlayV2.Plot
                 ? baseColor
                 : baseColor.WithAlpha(ContextAlpha);
         }
+
+        private float WidthFor(string channelLabel) =>
+            channelLabel == _focusedChannel ? FocusedLineWidth : ContextLineWidth;
 
         // ---------------- Public API ----------------
 
@@ -384,7 +413,7 @@ namespace CastleOverlayV2.Plot
                     s.Label = channelLabel;
                     s.Color = GetTraceColor(channelLabel);
                     s.LinePattern = LineStyleHelper.GetLinePattern(slot - 1);
-                    s.LineWidth = (float)LineStyleHelper.GetLineWidth(slot - 1);
+                    s.LineWidth = WidthFor(channelLabel);
                     s.MarkerSize = 0; // line-only — markers are noise (spec §6.3)
                     s.Axes.XAxis = xAxis;
                     s.Axes.YAxis = channelLabel switch
@@ -744,7 +773,7 @@ namespace CastleOverlayV2.Plot
                 s.Label = ch;
                 s.Color = GetTraceColor(ch);
                 s.LinePattern = LineStyleHelper.GetLinePattern(slot - 1);
-                s.LineWidth = (float)LineStyleHelper.GetLineWidth(slot - 1);
+                s.LineWidth = WidthFor(ch);
                 s.MarkerSize = 0; // line-only — markers are noise (spec §6.3)
                 s.Axes.XAxis = _plot.Plot.Axes.Bottom;
                 s.Axes.YAxis = ch == "RaceBox Speed" ? raceBoxSpeedAxis : raceBoxGxAxis;

--- a/src/CastleOverlayV2/Utils/LineStyleHelper.cs
+++ b/src/CastleOverlayV2/Utils/LineStyleHelper.cs
@@ -2,20 +2,12 @@
 
 namespace CastleOverlayV2.Utils
 {
+    /// <summary>
+    /// Run identity = line style (Run 1/RB 1 = solid, Run 2/RB 2 = dashed, Run 3/RB 3 = dotted).
+    /// Channel identity = colour. Focus identity = opacity + line width (in <see cref="Plot.PlotManager"/>).
+    /// </summary>
     public static class LineStyleHelper
     {
-        // ⬇️ Thickness per log run (index 0 = Log 1)
-        public static double GetLineWidth(int runIndex)
-        {
-            return runIndex switch
-            {
-                0 => 2.5, // Log 1 — boldest
-                1 => 1.5, // Log 2 — medium
-                2 => 1, // Log 3 — thinnest
-                _ => 2.0
-            };
-        }
-
         public static ScottPlot.LinePattern GetLinePattern(int index)
         {
             return index switch
@@ -23,10 +15,9 @@ namespace CastleOverlayV2.Utils
                 0 or 3 => ScottPlot.LinePattern.Solid,    // Run 1 and RaceBox 1
                 1 or 4 => ScottPlot.LinePattern.Dashed,   // Run 2 and RaceBox 2
                 2 or 5 => ScottPlot.LinePattern.Dotted,   // Run 3 and RaceBox 3
-                99 => ScottPlot.LinePattern.Dashed,         // ✅ RaceBox Split Lines
+                99 => ScottPlot.LinePattern.Dashed,         // RaceBox Split Lines
                 _ => ScottPlot.LinePattern.Solid
             };
         }
-
     }
 }


### PR DESCRIPTION
## Summary
Closes #74. The focus channel is now interactive — click a stat card body to focus that channel. The plot retints in real time, the visible Y axis rebinds, and the clicked card highlights.

## Diff
5 files, +100 / −41.

## PlotManager
- New `SetFocusedChannel(string)` — idempotent. Walks `_scatters`, updates `Color` (full opacity if it matches the new focus, dimmed otherwise) + `LineWidth`. Calls `ApplyFocusToAxes()` + `Refresh()`. **No replot** — pure style refresh.
- `WidthFor(channelLabel)` returns 2 px focused / 1.3 px context per spec §6.3.
- Scatter `LineWidth` is now focus-based, not slot-based.

## LineStyleHelper
- `GetLineWidth` removed — width is focus state, not run index.
- `GetLinePattern` stays (Run 1/RB 1 solid, Run 2/RB 2 dashed, Run 3/RB 3 dotted).
- 8 `GetLineWidth` unit tests removed; the 12 `GetLinePattern` tests intact.

## ChannelDrawer
- New `ChannelFocused` event (channel name).
- New `SetFocusedChannel(string)` — idempotent visual update.
- `ChannelCard.SetFocused(bool)`: focused card → `surface.card.focus` (#172230) bg + `text.accent` (#9AC7F2) name label.
- Card body, name label, and inner layout all wire `Click → Focused?.Invoke(...)`. The eye toggle and RPM-mode button keep their own click handlers and do not bubble.
- New theme tokens added: `SurfaceCardFocus`, `TextAccent`, `BorderFocus`.

## Presenter
- Subscribes `_drawer.ChannelFocused` in ctor.
- `OnChannelFocused(channelName)` calls `_plot.SetFocusedChannel(...)` and `_drawer.SetFocusedChannel(...)` — plot and drawer stay in sync.

## What this PR doesn't do
- Border-colour swap on focus — `Panel.BorderStyle` doesn't expose color. The brighter `surface.card.focus` background is the visual cue. Owner-drawing a colored border is a polish item, not in scope.
- Width animation on focus change. Direct switch is correct; the spec doesn't ask for animation here.

## Build / tests
\`\`\`
Build: 0 errors.
Passed!  - Failed: 0, Passed: 20, Skipped: 0, Total: 20
\`\`\`

## Test plan
- [ ] App opens, RPM is focused by default (RPM card brighter; RPM axis labels visible; other channels' lines are dim).
- [ ] Load 2 Castle runs.
- [ ] Click on Throttle %'s card body → Throttle becomes focused (bright, full width), RPM goes dim. Visible Y axis label changes to Throttle %. Throttle card brightens; RPM card returns to normal.
- [ ] Repeat with Voltage, Current, etc. Each click takes effect immediately.
- [ ] Click the eye (●) on a card → toggles visibility only. Focus does not change.
- [ ] Click the RPM card's `2 Pole / 4 Pole` button → mode flips; focus does not change.
- [ ] In the collapsed dot strip, click a dot → visibility toggles (no focus change).
- [ ] No regression in 2P / 4P toggle with all 6 slots loaded (regression check on #46).

## Accept criteria (spec §12.3)
> Focus changes the bright trace and the visible axis/labels.

## Workflow
Per repo `CLAUDE.md`: yours to merge — I will not run `gh pr merge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)