### PR TITLE
ui phase 4: run strip with chips + master visibility toggle (closes #75)

### DIFF
--- a/src/CastleOverlayV2/Controls/RunStrip.cs
+++ b/src/CastleOverlayV2/Controls/RunStrip.cs
@@ -1,0 +1,263 @@
+// File: src/CastleOverlayV2/Controls/RunStrip.cs
+using System;
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+
+namespace CastleOverlayV2.Controls
+{
+    /// <summary>
+    /// Thin top strip of one chip per slot (Docs/DragOverlay_UI_Spec.md §6.2).
+    /// Empty slots show a "Load …" button; loaded slots show a chip
+    /// (master eye toggle + source tag + truncated name + delete ×).
+    ///
+    /// Slot map: 1..3 = Castle (ESC), 4..6 = RaceBox (GPS).
+    /// </summary>
+    public class RunStrip : UserControl
+    {
+        // ---- Theme tokens ---------------------------------------------------
+        private static readonly Color SurfaceBar    = Color.FromArgb(0x1B, 0x21, 0x2B);
+        private static readonly Color SurfaceCard   = Color.FromArgb(0x1A, 0x1F, 0x27);
+        private static readonly Color SurfaceCardDim= Color.FromArgb(0x13, 0x17, 0x1E);
+        private static readonly Color TextPrimary   = Color.FromArgb(0xE6, 0xE9, 0xEF);
+        private static readonly Color TextSecond    = Color.FromArgb(0x9A, 0xA3, 0xB2);
+        private static readonly Color TextDim       = Color.FromArgb(0x5C, 0x65, 0x73);
+        private static readonly Color TextAccent    = Color.FromArgb(0x9A, 0xC7, 0xF2);
+        private static readonly Color BorderDef     = Color.FromArgb(0x29, 0x2F, 0x39);
+
+        // ---- Public events --------------------------------------------------
+        public event Action<int>? LoadRequested;   // slot 1..6
+        public event Action<int>? ToggleRequested; // slot 1..6
+        public event Action<int>? DeleteRequested; // slot 1..6
+
+        // ---- State ----------------------------------------------------------
+        private readonly SlotChip[] _chips = new SlotChip[7]; // index 1..6
+        private readonly FlowLayoutPanel _flow;
+        private readonly ToolTip _toolTip;
+
+        public RunStrip()
+        {
+            Dock = DockStyle.Top;
+            Height = 44;
+            BackColor = SurfaceBar;
+            ForeColor = TextPrimary;
+            Padding = new Padding(4, 4, 4, 4);
+
+            _toolTip = new ToolTip { AutoPopDelay = 8000, InitialDelay = 400, ReshowDelay = 200, ShowAlways = true };
+
+            _flow = new FlowLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                FlowDirection = FlowDirection.LeftToRight,
+                WrapContents = true,
+                AutoScroll = false,
+                BackColor = SurfaceBar,
+                Padding = new Padding(0),
+                Margin = new Padding(0)
+            };
+            Controls.Add(_flow);
+
+            for (int slot = 1; slot <= 6; slot++)
+            {
+                bool isCastle = slot <= 3;
+                string emptyLabel = isCastle ? $"Load Castle {slot}" : $"Load RaceBox {slot - 3}";
+                string sourceTag = isCastle ? "ESC" : "GPS";
+
+                var chip = new SlotChip(slot, emptyLabel, sourceTag, _toolTip);
+                chip.LoadClicked += () => LoadRequested?.Invoke(slot);
+                chip.ToggleClicked += () => ToggleRequested?.Invoke(slot);
+                chip.DeleteClicked += () => DeleteRequested?.Invoke(slot);
+                _chips[slot] = chip;
+                _flow.Controls.Add(chip);
+            }
+        }
+
+        // ---- Public API -----------------------------------------------------
+        public void SetSlotEmpty(int slot) => _chips[slot].SetEmpty();
+        public void SetSlotLoaded(int slot, string fullPath, bool isVisible) =>
+            _chips[slot].SetLoaded(fullPath, isVisible);
+        public void SetSlotToggleState(int slot, bool isVisible) =>
+            _chips[slot].SetToggleState(isVisible);
+        public void SetSlotVisible(int slot, bool visible) => _chips[slot].Visible = visible;
+
+        // ====================================================================
+        // Nested: one chip per slot
+        // ====================================================================
+        private class SlotChip : Panel
+        {
+            public int Slot { get; }
+
+            public event Action? LoadClicked;
+            public event Action? ToggleClicked;
+            public event Action? DeleteClicked;
+
+            private readonly Button _loadBtn;
+            private readonly Panel _loadedPanel;
+            private readonly Button _eyeBtn;
+            private readonly Label _tagLbl;
+            private readonly Label _nameLbl;
+            private readonly Button _deleteBtn;
+            private readonly ToolTip _toolTip;
+            private readonly string _emptyLabel;
+            private bool _isVisible = true;
+            private bool _isLoaded;
+
+            public SlotChip(int slot, string emptyLabel, string sourceTag, ToolTip toolTip)
+            {
+                Slot = slot;
+                _toolTip = toolTip;
+                _emptyLabel = emptyLabel;
+
+                Width = 188;
+                Height = 32;
+                BackColor = SurfaceCardDim;
+                Padding = new Padding(0);
+                Margin = new Padding(4, 2, 4, 2);
+
+                // --- "Load …" button (visible when slot empty) ---
+                _loadBtn = new Button
+                {
+                    Dock = DockStyle.Fill,
+                    Text = emptyLabel,
+                    FlatStyle = FlatStyle.Flat,
+                    BackColor = SurfaceCardDim,
+                    ForeColor = TextSecond,
+                    Font = new Font(SystemFonts.DefaultFont.FontFamily, 8.5f),
+                    TabStop = false
+                };
+                _loadBtn.FlatAppearance.BorderColor = BorderDef;
+                _loadBtn.FlatAppearance.BorderSize = 1;
+                _loadBtn.Click += (_, _) => LoadClicked?.Invoke();
+                Controls.Add(_loadBtn);
+
+                // --- Chip panel (visible when slot loaded) ---
+                _loadedPanel = new Panel
+                {
+                    Dock = DockStyle.Fill,
+                    BackColor = SurfaceCard,
+                    Padding = new Padding(0)
+                };
+
+                var layout = new TableLayoutPanel
+                {
+                    Dock = DockStyle.Fill,
+                    ColumnCount = 4,
+                    RowCount = 1,
+                    Margin = new Padding(0),
+                    Padding = new Padding(0)
+                };
+                layout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 26)); // eye
+                layout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 32)); // tag
+                layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100)); // name
+                layout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 22)); // ×
+
+                _eyeBtn = new Button
+                {
+                    Text = "●",
+                    Dock = DockStyle.Fill,
+                    FlatStyle = FlatStyle.Flat,
+                    BackColor = SurfaceCard,
+                    ForeColor = TextAccent,
+                    Margin = new Padding(0),
+                    Padding = new Padding(0),
+                    Font = new Font(SystemFonts.DefaultFont.FontFamily, 10f),
+                    TabStop = false
+                };
+                _eyeBtn.FlatAppearance.BorderSize = 0;
+                _eyeBtn.Click += (_, _) => ToggleClicked?.Invoke();
+                layout.Controls.Add(_eyeBtn, 0, 0);
+
+                _tagLbl = new Label
+                {
+                    Text = sourceTag,
+                    Dock = DockStyle.Fill,
+                    TextAlign = ContentAlignment.MiddleCenter,
+                    ForeColor = TextSecond,
+                    Font = new Font(SystemFonts.DefaultFont.FontFamily, 7.5f, FontStyle.Bold),
+                    Margin = new Padding(0),
+                    Padding = new Padding(0)
+                };
+                layout.Controls.Add(_tagLbl, 1, 0);
+
+                _nameLbl = new Label
+                {
+                    Text = "",
+                    Dock = DockStyle.Fill,
+                    TextAlign = ContentAlignment.MiddleLeft,
+                    ForeColor = TextPrimary,
+                    Font = new Font(SystemFonts.DefaultFont.FontFamily, 9f),
+                    AutoEllipsis = true,
+                    Margin = new Padding(0),
+                    Padding = new Padding(2, 0, 0, 0)
+                };
+                layout.Controls.Add(_nameLbl, 2, 0);
+
+                _deleteBtn = new Button
+                {
+                    Text = "×",
+                    Dock = DockStyle.Fill,
+                    FlatStyle = FlatStyle.Flat,
+                    BackColor = SurfaceCard,
+                    ForeColor = TextDim,
+                    Margin = new Padding(0),
+                    Padding = new Padding(0),
+                    Font = new Font(SystemFonts.DefaultFont.FontFamily, 12f, FontStyle.Bold),
+                    TabStop = false
+                };
+                _deleteBtn.FlatAppearance.BorderSize = 0;
+                _deleteBtn.Click += (_, _) => DeleteClicked?.Invoke();
+                layout.Controls.Add(_deleteBtn, 3, 0);
+
+                _loadedPanel.Controls.Add(layout);
+                Controls.Add(_loadedPanel);
+
+                ApplyLoadedState();
+            }
+
+            public void SetEmpty()
+            {
+                _isLoaded = false;
+                _isVisible = true;
+                _toolTip.SetToolTip(_nameLbl, string.Empty);
+                _nameLbl.Text = string.Empty;
+                ApplyLoadedState();
+            }
+
+            public void SetLoaded(string fullPath, bool isVisible)
+            {
+                _isLoaded = true;
+                _isVisible = isVisible;
+                _nameLbl.Text = Truncate(Path.GetFileName(fullPath) ?? string.Empty, 22);
+                _toolTip.SetToolTip(_nameLbl, fullPath);
+                UpdateEyeAppearance();
+                ApplyLoadedState();
+            }
+
+            public void SetToggleState(bool isVisible)
+            {
+                if (_isVisible == isVisible) return;
+                _isVisible = isVisible;
+                UpdateEyeAppearance();
+            }
+
+            private void ApplyLoadedState()
+            {
+                _loadBtn.Visible = !_isLoaded;
+                _loadedPanel.Visible = _isLoaded;
+            }
+
+            private void UpdateEyeAppearance()
+            {
+                _eyeBtn.Text = _isVisible ? "●" : "○";
+                _eyeBtn.ForeColor = _isVisible ? TextAccent : TextDim;
+            }
+
+            private static string Truncate(string s, int max)
+            {
+                if (s.Length <= max) return s;
+                if (max <= 3) return s.Substring(0, max);
+                return s.Substring(0, max - 3) + "...";
+            }
+        }
+    }
+}

--- a/src/CastleOverlayV2/MainForm.cs
+++ b/src/CastleOverlayV2/MainForm.cs
@@ -18,6 +18,7 @@ namespace CastleOverlayV2
         private readonly ConfigService _configService;
         private readonly PlotManager _plotManager;
         private ChannelDrawer _channelDrawer;
+        private RunStrip _runStrip;
         private MainFormPresenter _presenter;
 
         public MainForm(ConfigService configService)
@@ -41,14 +42,6 @@ namespace CastleOverlayV2
 
             Logger.Log("MainForm initialized");
             Logger.Log($"🟢 New Session Started — {DateTime.Now}");
-
-            // Disable per-slot action buttons until a run is loaded.
-            DisableAllSlotButtons();
-            for (int i = 1; i <= 3; i++)
-            {
-                SetSlotShiftButtonsEnabled(i, false, isRaceBox: false);
-                SetSlotShiftButtonsEnabled(i, false, isRaceBox: true);
-            }
 
             this.WindowState = FormWindowState.Maximized;
 
@@ -90,6 +83,22 @@ namespace CastleOverlayV2
 
             _plotManager.ResetEmptyPlot();
 
+            // Phase 4: the legacy top button panel is replaced by the new RunStrip
+            // (chip-per-slot). The Designer-named buttons inside still exist but are
+            // hidden via topButtonPanel.Visible = false; the runTypeSwitch (Drag/Speed
+            // pill) lives in headerRow's column 1 and stays visible.
+            topButtonPanel.Visible = false;
+
+            _runStrip = new RunStrip();
+            Controls.Add(_runStrip); // Dock = Top
+            _runStrip.LoadRequested += slot =>
+            {
+                if (slot <= 3) _ = _presenter.LoadCastleRunAsync(slot);
+                else _ = _presenter.LoadRaceBoxRunAsync(slot - 3);
+            };
+            _runStrip.ToggleRequested += slot => _presenter.ToggleRun(slot);
+            _runStrip.DeleteRequested += slot => _presenter.DeleteRun(slot);
+
             // Presenter owns all run state + business logic. It subscribes to plot/toggle events.
             _presenter = new MainFormPresenter(this, _configService, _plotManager, _channelDrawer);
 
@@ -119,126 +128,16 @@ namespace CastleOverlayV2
         public void ShowInfo(string title, string message) =>
             MessageBox.Show(message, title, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
-        /// <summary>A run was successfully loaded into <paramref name="slot"/>. Update button text + enable controls.</summary>
-        public void SetSlotLoadedUI(int slot, string loadButtonText, bool isVisible)
-        {
-            switch (slot)
-            {
-                case 1:
-                    btnLoadRun1.Text = loadButtonText;
-                    btnToggleRun1.Enabled = true;
-                    btnDeleteRun1.Enabled = true;
-                    btnToggleRun1.Text = isVisible ? "Hide" : "Show";
-                    SetSlotShiftButtonsEnabled(1, true, isRaceBox: false);
-                    break;
-                case 2:
-                    btnLoadRun2.Text = loadButtonText;
-                    btnToggleRun2.Enabled = true;
-                    btnDeleteRun2.Enabled = true;
-                    btnToggleRun2.Text = isVisible ? "Hide" : "Show";
-                    SetSlotShiftButtonsEnabled(2, true, isRaceBox: false);
-                    break;
-                case 3:
-                    btnLoadRun3.Text = loadButtonText;
-                    btnToggleRun3.Enabled = true;
-                    btnDeleteRun3.Enabled = true;
-                    btnToggleRun3.Text = isVisible ? "Hide" : "Show";
-                    SetSlotShiftButtonsEnabled(3, true, isRaceBox: false);
-                    break;
-                case 4:
-                    btnLoadRaceBox1.Text = loadButtonText;
-                    btnToggleRaceBox1.Enabled = true;
-                    btnDeleteRaceBox1.Enabled = true;
-                    btnToggleRaceBox1.Text = isVisible ? "Hide" : "Show";
-                    SetSlotShiftButtonsEnabled(1, true, isRaceBox: true);
-                    break;
-                case 5:
-                    btnLoadRaceBox2.Text = loadButtonText;
-                    btnToggleRaceBox2.Enabled = true;
-                    btnDeleteRaceBox2.Enabled = true;
-                    btnToggleRaceBox2.Text = isVisible ? "Hide" : "Show";
-                    SetSlotShiftButtonsEnabled(2, true, isRaceBox: true);
-                    break;
-                case 6:
-                    btnLoadRaceBox3.Text = loadButtonText;
-                    btnToggleRaceBox3.Enabled = true;
-                    btnDeleteRaceBox3.Enabled = true;
-                    btnToggleRaceBox3.Text = isVisible ? "Hide" : "Show";
-                    SetSlotShiftButtonsEnabled(3, true, isRaceBox: true);
-                    break;
-            }
-        }
+        /// <summary>A run was successfully loaded into <paramref name="slot"/>. Updates the run-strip chip.</summary>
+        public void SetSlotLoadedUI(int slot, string fullPath, bool isVisible) =>
+            _runStrip.SetSlotLoaded(slot, fullPath, isVisible);
 
-        /// <summary>Reset a slot's per-slot buttons to the empty/unloaded state.</summary>
-        public void ResetSlotUI(int slot)
-        {
-            switch (slot)
-            {
-                case 1:
-                    btnLoadRun1.Enabled = true;
-                    btnLoadRun1.Text = "Load Run 1";
-                    btnToggleRun1.Enabled = false;
-                    btnToggleRun1.Text = "Hide";
-                    btnDeleteRun1.Enabled = false;
-                    SetSlotShiftButtonsEnabled(1, false, isRaceBox: false);
-                    break;
-                case 2:
-                    btnLoadRun2.Enabled = true;
-                    btnLoadRun2.Text = "Load Run 2";
-                    btnToggleRun2.Enabled = false;
-                    btnToggleRun2.Text = "Hide";
-                    btnDeleteRun2.Enabled = false;
-                    SetSlotShiftButtonsEnabled(2, false, isRaceBox: false);
-                    break;
-                case 3:
-                    btnLoadRun3.Enabled = true;
-                    btnLoadRun3.Text = "Load Run 3";
-                    btnToggleRun3.Enabled = false;
-                    btnToggleRun3.Text = "Hide";
-                    btnDeleteRun3.Enabled = false;
-                    SetSlotShiftButtonsEnabled(3, false, isRaceBox: false);
-                    break;
-                case 4:
-                    btnLoadRaceBox1.Enabled = true;
-                    btnLoadRaceBox1.Text = "Load RaceBox 1";
-                    btnToggleRaceBox1.Enabled = false;
-                    btnToggleRaceBox1.Text = "Hide";
-                    btnDeleteRaceBox1.Enabled = false;
-                    SetSlotShiftButtonsEnabled(1, false, isRaceBox: true);
-                    break;
-                case 5:
-                    btnLoadRaceBox2.Enabled = true;
-                    btnLoadRaceBox2.Text = "Load RaceBox 2";
-                    btnToggleRaceBox2.Enabled = false;
-                    btnToggleRaceBox2.Text = "Hide";
-                    btnDeleteRaceBox2.Enabled = false;
-                    SetSlotShiftButtonsEnabled(2, false, isRaceBox: true);
-                    break;
-                case 6:
-                    btnLoadRaceBox3.Enabled = true;
-                    btnLoadRaceBox3.Text = "Load RaceBox 3";
-                    btnToggleRaceBox3.Enabled = false;
-                    btnToggleRaceBox3.Text = "Hide";
-                    btnDeleteRaceBox3.Enabled = false;
-                    SetSlotShiftButtonsEnabled(3, false, isRaceBox: true);
-                    break;
-            }
-        }
+        /// <summary>Reset a slot's chip back to the empty (Load …) state.</summary>
+        public void ResetSlotUI(int slot) => _runStrip.SetSlotEmpty(slot);
 
-        /// <summary>Update a slot's toggle button label ("Hide"/"Show") after a visibility flip.</summary>
-        public void SetSlotToggleText(int slot, bool isVisible)
-        {
-            string txt = isVisible ? "Hide" : "Show";
-            switch (slot)
-            {
-                case 1: btnToggleRun1.Text = txt; break;
-                case 2: btnToggleRun2.Text = txt; break;
-                case 3: btnToggleRun3.Text = txt; break;
-                case 4: if (!btnToggleRaceBox1.IsDisposed && btnToggleRaceBox1.Visible) btnToggleRaceBox1.Text = txt; break;
-                case 5: if (!btnToggleRaceBox2.IsDisposed && btnToggleRaceBox2.Visible) btnToggleRaceBox2.Text = txt; break;
-                case 6: if (!btnToggleRaceBox3.IsDisposed && btnToggleRaceBox3.Visible) btnToggleRaceBox3.Text = txt; break;
-            }
-        }
+        /// <summary>Update a slot's master eye toggle after a visibility flip.</summary>
+        public void SetSlotToggleText(int slot, bool isVisible) =>
+            _runStrip.SetSlotToggleState(slot, isVisible);
 
         /// <summary>Sync the RunType pill switch appearance with current mode + lock state.</summary>
         public void UpdateRunTypeLockState() => SyncRunTypeUI(_presenter?.IsSpeedRunMode ?? false, _presenter?.IsAnyRunLoaded ?? false);
@@ -365,98 +264,14 @@ namespace CastleOverlayV2
             ApplyRunTypeUI(isSpeedRun);
         }
 
-        /// <summary>Speed mode hides all RaceBox rows + Castle Run 3.</summary>
+        /// <summary>Speed mode hides Castle Run 3 + all RaceBox chips in the run strip.</summary>
         public void ApplyRunTypeUI(bool isSpeedRun)
         {
-            // RaceBox 1
-            btnLoadRaceBox1.Visible = !isSpeedRun;
-            btnShiftLeftRB1.Visible = !isSpeedRun;
-            btnShiftRightRB1.Visible = !isSpeedRun;
-            btnMenuRB1.Visible = !isSpeedRun;
-
-            // RaceBox 2
-            btnLoadRaceBox2.Visible = !isSpeedRun;
-            btnShiftLeftRB2.Visible = !isSpeedRun;
-            btnShiftRightRB2.Visible = !isSpeedRun;
-            btnMenuRB2.Visible = !isSpeedRun;
-
-            // RaceBox 3
-            btnLoadRaceBox3.Visible = !isSpeedRun;
-            btnShiftLeftRB3.Visible = !isSpeedRun;
-            btnShiftRightRB3.Visible = !isSpeedRun;
-            btnMenuRB3.Visible = !isSpeedRun;
-
-            // Castle Run 3
-            btnLoadRun3.Visible = !isSpeedRun;
-            btnShiftLeftRun3.Visible = !isSpeedRun;
-            btnShiftRightRun3.Visible = !isSpeedRun;
-            btnMenuRun3.Visible = !isSpeedRun;
-
-            topButtonPanel?.PerformLayout();
-            topButtonPanel?.Refresh();
-        }
-
-        private void DisableAllSlotButtons()
-        {
-            btnToggleRun1.Enabled = false;
-            btnDeleteRun1.Enabled = false;
-            btnToggleRun2.Enabled = false;
-            btnDeleteRun2.Enabled = false;
-            btnToggleRun3.Enabled = false;
-            btnDeleteRun3.Enabled = false;
-
-            btnToggleRaceBox1.Enabled = false;
-            btnDeleteRaceBox1.Enabled = false;
-            btnToggleRaceBox2.Enabled = false;
-            btnDeleteRaceBox2.Enabled = false;
-            btnToggleRaceBox3.Enabled = false;
-            btnDeleteRaceBox3.Enabled = false;
-        }
-
-        private void SetSlotShiftButtonsEnabled(int uiSlot, bool enabled, bool isRaceBox)
-        {
-            if (!isRaceBox)
-            {
-                switch (uiSlot)
-                {
-                    case 1:
-                        btnShiftLeftRun1.Enabled = enabled;
-                        btnShiftRightRun1.Enabled = enabled;
-                        btnShiftResetRun1.Enabled = enabled;
-                        break;
-                    case 2:
-                        btnShiftLeftRun2.Enabled = enabled;
-                        btnShiftRightRun2.Enabled = enabled;
-                        btnShiftResetRun2.Enabled = enabled;
-                        break;
-                    case 3:
-                        btnShiftLeftRun3.Enabled = enabled;
-                        btnShiftRightRun3.Enabled = enabled;
-                        btnShiftResetRun3.Enabled = enabled;
-                        break;
-                }
-            }
-            else
-            {
-                switch (uiSlot)
-                {
-                    case 1:
-                        btnShiftLeftRB1.Enabled = enabled;
-                        btnShiftRightRB1.Enabled = enabled;
-                        btnShiftResetRB1.Enabled = enabled;
-                        break;
-                    case 2:
-                        btnShiftLeftRB2.Enabled = enabled;
-                        btnShiftRightRB2.Enabled = enabled;
-                        btnShiftResetRB2.Enabled = enabled;
-                        break;
-                    case 3:
-                        btnShiftLeftRB3.Enabled = enabled;
-                        btnShiftRightRB3.Enabled = enabled;
-                        btnShiftResetRB3.Enabled = enabled;
-                        break;
-                }
-            }
+            // Castle Run 3 + all RaceBox slots hide in Speed-Run mode.
+            _runStrip?.SetSlotVisible(3, !isSpeedRun);
+            _runStrip?.SetSlotVisible(4, !isSpeedRun);
+            _runStrip?.SetSlotVisible(5, !isSpeedRun);
+            _runStrip?.SetSlotVisible(6, !isSpeedRun);
         }
     }
 }

--- a/src/CastleOverlayV2/MainFormPresenter.cs
+++ b/src/CastleOverlayV2/MainFormPresenter.cs
@@ -100,7 +100,7 @@ namespace CastleOverlayV2
                 _plot.SetupAllAxes();
                 _plot.RefreshPlot();
 
-                _view.SetSlotLoadedUI(slot, $"Run {slot}: {Path.GetFileName(path)}", _plot.GetRunVisibility(slot));
+                _view.SetSlotLoadedUI(slot, path, _plot.GetRunVisibility(slot));
 
                 // Surface any non-fatal warning (e.g. "no drag pass detected").
                 if (result.HasMessage) ShowResultMessage(result);
@@ -194,7 +194,7 @@ namespace CastleOverlayV2
                 EnsureRaceBoxChannelsInToggleBar();
                 PlotAllRuns();
 
-                _view.SetSlotLoadedUI(plotSlot, $"RaceBox {uiSlot}: {TruncateFileName(path)}", true);
+                _view.SetSlotLoadedUI(plotSlot, path, true);
             }
             catch (Exception ex)
             {
@@ -458,12 +458,5 @@ namespace CastleOverlayV2
                 _view.ShowError(result.Title!, result.Message!);
         }
 
-        private static string TruncateFileName(string filePath, int maxChars = 28)
-        {
-            string fileName = Path.GetFileName(filePath) ?? string.Empty;
-            if (fileName.Length <= maxChars) return fileName;
-            if (maxChars <= 3) return fileName.Substring(0, maxChars);
-            return fileName.Substring(0, maxChars - 3) + "...";
-        }
     }
 }


### PR DESCRIPTION
## Summary
Closes #75. Adds a thin top strip of one chip per slot per spec §6.2 — replaces the legacy per-slot button row.

## Diff
3 files, +296 / −225 (net **+71**, but `MainForm` shrinks by ~180 lines while `RunStrip` adds ~280).

## New: `Controls/RunStrip.cs`
Dock=Top, height 44, surface.bar background. Six `SlotChip` children (slots 1..6 = Castle 1..3, RaceBox 1..3) in a wrapping `FlowLayoutPanel`.

Each chip has two states:
\`\`\`
Empty:    [ Load Castle 1 ]
Loaded:   [● ESC  my_run.csv ×]
           ●  = master eye toggle (● visible / ○ hidden)
           ESC/GPS = source tag
           name   = ellipsis-truncated (full path in tooltip)
           ×      = delete
\`\`\`

Events: `LoadRequested(slot)`, `ToggleRequested(slot)`, `DeleteRequested(slot)`.

Public API: `SetSlotEmpty`, `SetSlotLoaded(slot, fullPath, isVisible)`, `SetSlotToggleState`, `SetSlotVisible` (the last is used by Speed-Run mode).

## MainForm changes
- New `_runStrip` field; created and added in ctor; events subscribed to the existing presenter methods.
- `topButtonPanel.Visible = false` (the old per-slot button row in headerRow column 0). The buttons themselves still exist; the Drag/Speed pill in headerRow column 1 stays visible.
- The big per-slot switches in `SetSlotLoadedUI` / `ResetSlotUI` / `SetSlotToggleText` collapse to one-line forwarders to the run strip (**−180 lines**).
- `DisableAllSlotButtons` + `SetSlotShiftButtonsEnabled` (and the two ctor calls to them) deleted — the buttons they touched are now hidden.
- `ApplyRunTypeUI` shrinks to a 4-line `_runStrip.SetSlotVisible` loop for Castle Run 3 + RaceBox 1/2/3 — same Speed-Run behavior, applied to chips instead of hidden buttons.

## Presenter changes
- `LoadCastleRunAsync` / `LoadRaceBoxRunAsync` now pass the **full path** (not a pre-formatted button text) to `SetSlotLoadedUI`. The chip handles its own truncation + tooltip.
- `TruncateFileName` helper deleted (RunStrip has its own).

## Master visibility toggle
Spec says the master eye toggle hides every line from that log at once **without losing per-channel toggles**. The existing `PlotManager.ToggleRunVisibility(slot)` already does exactly this — it flips `_runVisibility[slot]` and walks scatters setting `IsVisible = runVisible && channelVisible`. Per-channel state in `_channelVisibility` is untouched. No new state needed.

## Out of scope (later phases / followups)
- Right-click context menu on chips — spec didn't ask for #75.
- Drag-to-arm-alignment is Phase 6 (#77). Chip body click is a no-op for now.
- Removing `topButtonPanel` entirely + rehoming the Drag/Speed pill needs a Designer-file pass; deferred to a separate cleanup PR.

## Build / tests
\`\`\`
Build: 0 errors.
Passed!  - Failed: 0, Passed: 20, Skipped: 0, Total: 20
\`\`\`

## Test plan — please look at this with real data
This adds a new control across the top of the window. Watch for layout quirks.

- [ ] App opens. Top of window shows six chips: `Load Castle 1`, `Load Castle 2`, `Load Castle 3`, `Load RaceBox 1`, `Load RaceBox 2`, `Load RaceBox 3`.
- [ ] Drag/Speed pill still visible at right of the window.
- [ ] Click a `Load Castle N` chip → file picker opens → load a CSV. Chip flips to loaded state showing `● ESC  filename.csv  ×`.
- [ ] Hover the chip's filename → tooltip shows the full path.
- [ ] Click the ● → chip flips to ○; that run's lines hide on the plot; per-channel toggles in the drawer are unchanged. Click ○ → run reappears with the same channel visibility.
- [ ] Click `×` → run is deleted; chip flips back to `Load Castle N`.
- [ ] Load 2 Castle + 2 RaceBox runs. All four chips loaded; plot shows all four.
- [ ] Toggle 2P/4P in the drawer → all runs (incl. RaceBox) stay plotted (regression check on #46).
- [ ] Click Drag/Speed pill (only enabled with all chips empty) → in Speed mode, the slot-3 Castle chip + all RaceBox chips disappear. Switch back to Drag → they reappear.
- [ ] Long filename: chip truncates with `...` and tooltip still shows full path.

## Accept criteria (spec §12.4)
> Master toggle dims an entire log and restores prior state.

## Workflow
Per repo `CLAUDE.md`: yours to merge — I will not run `gh pr merge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)