### PR TITLE
ui phase 5: add RaceBox Distance channel + group GPS in drawer (closes #76)

### DIFF
--- a/src/CastleOverlayV2/Controls/ChannelDrawer.cs
+++ b/src/CastleOverlayV2/Controls/ChannelDrawer.cs
@@ -41,6 +41,7 @@ namespace CastleOverlayV2.Controls
         private string _focusedChannel = "RPM"; // matches PlotManager's initial focus
         private readonly Dictionary<string, ChannelCard> _cards = new();
         private readonly Dictionary<string, ChannelDot> _dots = new();
+        private bool _racBoxSeparatorAdded; // visual gap between Castle and RaceBox channels
 
         // ---- Layout containers ---------------------------------------------
         private readonly Panel _stripRow;       // collapsed view: chevron + dots
@@ -127,6 +128,14 @@ namespace CastleOverlayV2.Controls
         {
             if (_cards.ContainsKey(channelName)) return;
 
+            // Group RaceBox channels visually after Castle (spec §6.4).
+            bool isRaceBox = channelName.StartsWith("RaceBox", StringComparison.Ordinal);
+            if (isRaceBox && !_racBoxSeparatorAdded)
+            {
+                AddSourceGroupSeparator();
+                _racBoxSeparatorAdded = true;
+            }
+
             var card = new ChannelCard(channelName, initialVisible);
             card.VisibilityChanged += (n, v) =>
             {
@@ -211,6 +220,31 @@ namespace CastleOverlayV2.Controls
             PerformLayout();
         }
 
+        /// <summary>
+        /// Insert a slim vertical separator into both the card grid and the dot strip so the
+        /// RaceBox channels read as a set distinct from the Castle channels.
+        /// </summary>
+        private void AddSourceGroupSeparator()
+        {
+            var cardSep = new Panel
+            {
+                Width = 2,
+                Height = 80,
+                BackColor = BorderDef,
+                Margin = new Padding(8, 6, 8, 6)
+            };
+            _cardFlow.Controls.Add(cardSep);
+
+            var dotSep = new Panel
+            {
+                Width = 2,
+                Height = 18,
+                BackColor = BorderDef,
+                Margin = new Padding(8, 7, 8, 7)
+            };
+            _dotFlow.Controls.Add(dotSep);
+        }
+
         private Button MakeChevronButton(bool expandedNow)
         {
             var b = new Button
@@ -250,6 +284,7 @@ namespace CastleOverlayV2.Controls
                 "Current" => v.ToString("F1"),
                 "Acceleration" => v.ToString("F2"),
                 "RaceBox Speed" => v.ToString("F1"),
+                "RaceBox Distance" => v.ToString("F0"),
                 "RaceBox G-Force X" => v.ToString("F2"),
                 _ => v.ToString("F2"),
             };
@@ -562,6 +597,7 @@ namespace CastleOverlayV2.Controls
                 "MotorTiming" => "Tim",
                 "Acceleration" => "Acc",
                 "RaceBox Speed" => "Spd",
+                "RaceBox Distance" => "Dst",
                 "RaceBox G-Force X" => "Gx",
                 _ => channelName.Substring(0, Math.Min(3, channelName.Length))
             };

--- a/src/CastleOverlayV2/MainFormPresenter.cs
+++ b/src/CastleOverlayV2/MainFormPresenter.cs
@@ -182,6 +182,7 @@ namespace CastleOverlayV2
                 run.Data["RaceBox G-Force X"] = points
                     .Select(p => new DataPoint { Time = p.Time.TotalSeconds, Y = p.GForceX })
                     .ToList();
+                run.Data["RaceBox Distance"] = IntegrateDistanceFeet(points);
                 // PlotManager skips runs with empty DataPoints — populate with time-only dummies.
                 run.DataPoints = points
                     .Select(p => new DataPoint { Time = p.Time.TotalSeconds })
@@ -214,6 +215,11 @@ namespace CastleOverlayV2
                 _drawer.AddChannel("RaceBox Speed", true);
                 added = true;
             }
+            if (!states.ContainsKey("RaceBox Distance"))
+            {
+                _drawer.AddChannel("RaceBox Distance", true);
+                added = true;
+            }
             if (!states.ContainsKey("RaceBox G-Force X"))
             {
                 _drawer.AddChannel("RaceBox G-Force X", true);
@@ -224,6 +230,34 @@ namespace CastleOverlayV2
                 _drawer.PerformLayout();
                 _drawer.Refresh();
             }
+        }
+
+        /// <summary>
+        /// Cumulative distance (feet) along the run, integrated from RaceBox speed at each sample.
+        /// Rectangular integration is good enough for ~25 Hz data.
+        /// </summary>
+        private static List<DataPoint> IntegrateDistanceFeet(List<Models.RaceBoxPoint> points)
+        {
+            const double FeetPerMile = 5280.0;
+            const double SecondsPerHour = 3600.0;
+            const double MphToFeetPerSec = FeetPerMile / SecondsPerHour; // = 1.46667
+
+            var result = new List<DataPoint>(points.Count);
+            double distFt = 0;
+            double prevSec = points.Count > 0 ? points[0].Time.TotalSeconds : 0;
+            for (int i = 0; i < points.Count; i++)
+            {
+                double sec = points[i].Time.TotalSeconds;
+                if (i > 0)
+                {
+                    double dt = sec - prevSec;
+                    if (dt > 0)
+                        distFt += Math.Max(0, points[i].SpeedMph) * MphToFeetPerSec * dt;
+                }
+                result.Add(new DataPoint { Time = sec, Y = distFt });
+                prevSec = sec;
+            }
+            return result;
         }
 
         // ============================================================
@@ -357,7 +391,7 @@ namespace CastleOverlayV2
         {
             "RPM", "Throttle %", "Voltage", "Current", "Ripple", "PowerOut",
             "ESC Temp", "MotorTemp", "MotorTiming", "Acceleration",
-            "RaceBox Speed", "RaceBox G-Force X",
+            "RaceBox Speed", "RaceBox Distance", "RaceBox G-Force X",
         };
 
         private void PushAllStatsToDrawer()

--- a/src/CastleOverlayV2/Plot/PlotManager.cs
+++ b/src/CastleOverlayV2/Plot/PlotManager.cs
@@ -78,6 +78,7 @@ namespace CastleOverlayV2.Plot
         private IYAxis accelAxis;
         private IYAxis raceBoxSpeedAxis;
         private IYAxis raceBoxGxAxis;
+        private IYAxis raceBoxDistanceAxis;
 
         // Events
         public event Action<Dictionary<string, double?[]>> CursorMoved;
@@ -585,6 +586,13 @@ namespace CastleOverlayV2.Plot
                 HideAxis(raceBoxGxAxis);
             }
 
+            if (raceBoxDistanceAxis is null)
+            {
+                raceBoxDistanceAxis = _plot.Plot.Axes.AddRightAxis();
+                raceBoxDistanceAxis.Label.Text = "Distance (ft)";
+                HideAxis(raceBoxDistanceAxis);
+            }
+
             // Show the focused channel's axis with its hue; keep the rest hidden.
             ApplyFocusToAxes();
 
@@ -602,7 +610,7 @@ namespace CastleOverlayV2.Plot
             foreach (var axis in new IAxis?[] {
                 throttleAxis, rpmAxis, voltageAxis, currentAxis, rippleAxis, powerAxis,
                 escTempAxis, motorTempAxis, motorTimingAxis, accelAxis,
-                raceBoxSpeedAxis, raceBoxGxAxis })
+                raceBoxSpeedAxis, raceBoxGxAxis, raceBoxDistanceAxis })
             {
                 if (axis is not null) HideAxis(axis);
             }
@@ -634,6 +642,7 @@ namespace CastleOverlayV2.Plot
             "MotorTiming" => motorTimingAxis,
             "Acceleration" => accelAxis,
             "RaceBox Speed" => raceBoxSpeedAxis,
+            "RaceBox Distance" => raceBoxDistanceAxis,
             "RaceBox G-Force X" => raceBoxGxAxis,
             _ => null
         };
@@ -648,7 +657,7 @@ namespace CastleOverlayV2.Plot
             {
                 throttleAxis, rpmAxis, voltageAxis, currentAxis, rippleAxis, powerAxis,
                 escTempAxis, motorTempAxis, motorTimingAxis, accelAxis,
-                raceBoxSpeedAxis, raceBoxGxAxis, _splitLabelAxis
+                raceBoxSpeedAxis, raceBoxGxAxis, raceBoxDistanceAxis, _splitLabelAxis
             }.Where(a => a is not null)!);
 
             var toRemove = new List<IAxisRule>();
@@ -662,6 +671,8 @@ namespace CastleOverlayV2.Plot
                 _plot.Plot.Axes.Rules.Add(new LockedVertical(raceBoxSpeedAxis, 0, 110));
             if (raceBoxGxAxis is not null)
                 _plot.Plot.Axes.Rules.Add(new LockedVertical(raceBoxGxAxis, -5, 7));
+            if (raceBoxDistanceAxis is not null)
+                _plot.Plot.Axes.Rules.Add(new LockedVertical(raceBoxDistanceAxis, 0, 1000));
             if (_splitLabelAxis is not null)
                 _plot.Plot.Axes.Rules.Add(new LockedVertical(_splitLabelAxis, 0.0, 1.0));
 
@@ -755,7 +766,7 @@ namespace CastleOverlayV2.Plot
         {
             if (run == null || !run.IsRaceBox) return;
 
-            var channels = new[] { "RaceBox Speed", "RaceBox G-Force X" };
+            var channels = new[] { "RaceBox Speed", "RaceBox Distance", "RaceBox G-Force X" };
             foreach (var ch in channels)
             {
                 if (!run.Data.TryGetValue(ch, out var pts) || pts.Count == 0)
@@ -776,7 +787,12 @@ namespace CastleOverlayV2.Plot
                 s.LineWidth = WidthFor(ch);
                 s.MarkerSize = 0; // line-only — markers are noise (spec §6.3)
                 s.Axes.XAxis = _plot.Plot.Axes.Bottom;
-                s.Axes.YAxis = ch == "RaceBox Speed" ? raceBoxSpeedAxis : raceBoxGxAxis;
+                s.Axes.YAxis = ch switch
+                {
+                    "RaceBox Speed" => raceBoxSpeedAxis,
+                    "RaceBox Distance" => raceBoxDistanceAxis,
+                    _ => raceBoxGxAxis,
+                };
 
                 bool chOn = _channelVisibility.TryGetValue(ch, out var vis) ? vis : true;
                 bool runOn = _runVisibility.TryGetValue(slot, out var rvis) ? rvis : true;
@@ -979,7 +995,7 @@ namespace CastleOverlayV2.Plot
                 _plot.Plot.Axes.Left,
                 throttleAxis, rpmAxis, voltageAxis, currentAxis, rippleAxis, powerAxis,
                 escTempAxis, motorTempAxis, motorTimingAxis, accelAxis,
-                raceBoxSpeedAxis, raceBoxGxAxis
+                raceBoxSpeedAxis, raceBoxGxAxis, raceBoxDistanceAxis
             }.Where(a => a != null).ToList();
 
             foreach (var axis in allAxes)

--- a/src/CastleOverlayV2/Utils/ColorMap.cs
+++ b/src/CastleOverlayV2/Utils/ColorMap.cs
@@ -24,6 +24,7 @@ namespace CastleOverlayV2.Utils
 
             // RaceBox GPS channels
             { "RaceBox Speed", new ScottPlot.Color(0xD4, 0x53, 0x7E) },     // #D4537E  pink
+            { "RaceBox Distance", new ScottPlot.Color(0x63, 0x99, 0x22) },  // #639922  dark green
             { "RaceBox G-Force X", new ScottPlot.Color(0x9F, 0x8F, 0xE0) }, // #9F8FE0  light purple
         };
 


### PR DESCRIPTION
## Summary
Closes #76. Adds GPS distance as a third RaceBox channel and visually separates RaceBox cards/dots from Castle ones in the drawer per spec §6.4.

## Diff
4 files, +93 / −6.

## Distance channel
- Integrated from `SpeedMph` at parse time (rectangular integration, fine for ~25 Hz data).
- Helper `IntegrateDistanceFeet` in `MainFormPresenter`: per-sample `dt × mph × (5280/3600)` ft/s/mph, cumulative. Clamped at ≥ 0 to ignore negative-speed jitter.
- Surfaced as `run.Data["RaceBox Distance"]` alongside Speed and G-Force X.

## Plot
- New `raceBoxDistanceAxis` (right axis, hidden by default).
- Locked **0–1000 ft** (covers a full drag pass + buffer).
- `PlotRaceBoxRun` loops over { Speed, Distance, G-Force X }; YAxis switch routes each channel to its dedicated axis.
- Lists in `ApplyFocusToAxes` / `ReapplyAxisLocks` / `ResetEmptyPlot` all updated.

## Palette
`"RaceBox Distance"` → `#639922` (dark green, spec §5).

## Drawer grouping
- `AddChannel` detects the first `RaceBox`-prefixed channel and inserts a slim **2 px vertical separator** into both the card grid and the dot strip. RaceBox cards/dots then sit visually distinct from Castle.
- Short label "Dst", `F0` number format (whole feet).

## Presenter
- `"RaceBox Distance"` added to `_knownChannels` so `PushAllStatsToDrawer` populates max/avg on the new card.
- `EnsureRaceBoxChannelsInToggleBar` adds the Distance card alongside Speed and G-Force X on first RaceBox load.

## Build / tests
\`\`\`
Build: 0 errors.
Passed!  - Failed: 0, Passed: 20, Skipped: 0, Total: 20
\`\`\`

## Test plan
- [ ] App opens; drawer shows Castle cards only. No separator yet.
- [ ] Load a RaceBox CSV → three new cards appear: Speed, Distance, G-Force X. Slim vertical separator appears between the Castle group and the RaceBox group in both the expanded cards AND the collapsed dot strip.
- [ ] Focus the Distance card → Y axis label reads `Distance (ft)`, scale 0–1000, trace bright dark-green; other channels dim.
- [ ] Cursor hover updates @cursor Distance value in card.
- [ ] Stats card shows `RB 1 max XXX · avg YYY` for Distance — max should be the final-sample value (cumulative).
- [ ] Existing Speed and G-Force X channels still plot and update correctly.

## Accept criteria (spec §12.5)
> A GPS log loads and its channels (Speed, Distance, G-force) overlay correctly with ESC channels.

## Workflow
Per repo `CLAUDE.md`: yours to merge — I will not run `gh pr merge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)