### PR TITLE
fix: score Castle drag-pass candidates for auto-trim

### DIFF
--- a/Tests/CastleOverlayV2.Tests/DragPassDetectorTests.cs
+++ b/Tests/CastleOverlayV2.Tests/DragPassDetectorTests.cs
@@ -1,0 +1,89 @@
+using CastleOverlayV2.Models;
+using CastleOverlayV2.Services;
+
+namespace CastleOverlayV2.Tests;
+
+public class DragPassDetectorTests
+{
+    [Fact]
+    public void Selects_stronger_real_pass_over_earlier_false_event()
+    {
+        List<DataPoint> data = Idle(30);
+        AddBurst(data, current: 60, power: 78, rpm: 124_000, acceleration: 1.5, samples: 18);
+        data.AddRange(Idle(120, data.Count));
+        int expectedLaunch = data.Count;
+        AddBurst(data, current: 670, power: 100, rpm: 171_000, acceleration: -4.1, samples: 35);
+
+        DragPassDetectionResult result = DragPassDetector.Detect(data, 0.05);
+
+        Assert.True(result.Found);
+        Assert.InRange(result.LaunchIndex, expectedLaunch, expectedLaunch + 2);
+    }
+
+    [Fact]
+    public void Does_not_require_positive_acceleration()
+    {
+        List<DataPoint> data = Idle(40);
+        int expectedLaunch = data.Count;
+        AddBurst(data, current: 520, power: 100, rpm: 150_000, acceleration: -3.2, samples: 30);
+
+        DragPassDetectionResult result = DragPassDetector.Detect(data, 0.05);
+
+        Assert.True(result.Found);
+        Assert.InRange(result.LaunchIndex, expectedLaunch, expectedLaunch + 2);
+    }
+
+    [Fact]
+    public void Ignores_bad_marked_power_when_detecting_launch()
+    {
+        List<DataPoint> data = Idle(20);
+        for (int i = 0; i < 15; i++)
+        {
+            data.Add(Point(data.Count, current: 0, power: 100, rpm: 0, acceleration: 0, powerValid: false));
+        }
+
+        DragPassDetectionResult result = DragPassDetector.Detect(data, 0.05);
+
+        Assert.False(result.Found);
+    }
+
+    private static List<DataPoint> Idle(int count, int startIndex = 0)
+    {
+        var data = new List<DataPoint>();
+        for (int i = 0; i < count; i++)
+            data.Add(Point(startIndex + i, current: 0, power: 0, rpm: 0, acceleration: 0));
+        return data;
+    }
+
+    private static void AddBurst(List<DataPoint> data, double current, double power, double rpm, double acceleration, int samples)
+    {
+        for (int i = 0; i < samples; i++)
+        {
+            double scale = Math.Min(1.0, 0.35 + i * 0.08);
+            data.Add(Point(data.Count, current * scale, power * scale, rpm * scale, acceleration));
+        }
+    }
+
+    private static DataPoint Point(
+        int index,
+        double current,
+        double power,
+        double rpm,
+        double acceleration,
+        bool powerValid = true)
+    {
+        return new DataPoint
+        {
+            Time = index * 0.05,
+            Throttle = current > 0 ? 1.8 : 1.5,
+            PowerOut = power,
+            PowerOutValid = powerValid,
+            Current = current,
+            CurrentValid = true,
+            Speed = rpm,
+            SpeedValid = true,
+            Acceleration = acceleration
+        };
+    }
+
+}

--- a/src/CastleOverlayV2/Models/DataPoint.cs
+++ b/src/CastleOverlayV2/Models/DataPoint.cs
@@ -16,6 +16,10 @@
         public double MotorTiming { get; set; }
         public double Acceleration { get; set; }
 
+        public bool PowerOutValid { get; set; } = true;
+        public bool CurrentValid { get; set; } = true;
+        public bool SpeedValid { get; set; } = true;
+
         // ✅ RaceBox Y-axis data for plotting (used for RaceBox Speed / G-X only)
         public double Y { get; set; }
 

--- a/src/CastleOverlayV2/Services/CsvLoader.cs
+++ b/src/CastleOverlayV2/Services/CsvLoader.cs
@@ -60,6 +60,7 @@ namespace CastleOverlayV2.Services
                 NeutralMs = 1.500,
                 MaxMs = 1.910    // Full Forward
             };
+            double sampleIntervalSeconds = 0.05;
 
             using (var reader = new StreamReader(filePath))
             {
@@ -93,6 +94,12 @@ namespace CastleOverlayV2.Services
                             if (double.TryParse(
                                 meta.Split(':').Last().Replace("ms", "", StringComparison.OrdinalIgnoreCase).Trim(),
                                 NumberStyles.Any, CultureInfo.InvariantCulture, out double v)) cal.MaxMs = v;
+                        }
+                        else if (meta.Contains("Sample Time:", StringComparison.OrdinalIgnoreCase))
+                        {
+                            string sampleTimeText = meta.Split("Sample Time:", StringSplitOptions.RemoveEmptyEntries).Last().Trim();
+                            if (double.TryParse(sampleTimeText, NumberStyles.Any, CultureInfo.InvariantCulture, out double v) && v > 0)
+                                sampleIntervalSeconds = v;
                         }
                     }
                     else
@@ -128,66 +135,65 @@ namespace CastleOverlayV2.Services
 
                     int rowIndex = 0;
                     const int rowMax = 10000;
-                    bool launchPointFound = false;
 
                     while (csv.Read())
                     {
+                        string rawRecord = csv.Parser.RawRecord ?? string.Empty;
+                        if (rawRecord.TrimStart().StartsWith("#", StringComparison.Ordinal))
+                        {
+                            log?.WriteLine("Next Castle session encountered; stopping at first session.");
+                            break;
+                        }
+
                         if (rowIndex > rowMax)
                         {
                             log?.WriteLine("Row limit hit!");
                             break;
                         }
 
-                        string rawPowerOut = csv.GetField<string>("Power-Out");
-                        double powerOut = 0.0;
-                        if (!string.IsNullOrWhiteSpace(rawPowerOut))
-                        {
-                            rawPowerOut = rawPowerOut.Replace("b", "").Replace("%", "").Trim();
-                            double.TryParse(rawPowerOut, NumberStyles.Any, CultureInfo.InvariantCulture, out powerOut);
-                        }
-
-                        if (trimForDrag)
-                        {
-                            if (!launchPointFound && powerOut >= 5.0)
-                            {
-                                launchPointFound = true;
-                                log?.WriteLine($"Launch found at row {rowIndex}");
-                            }
-                            if (!launchPointFound)
-                            {
-                                rowIndex++;
-                                continue;
-                            }
-                        }
-
                         string rpmField = csv.HeaderRecord.Contains("RPM") ? "RPM" : "Speed";
 
-                        double GetDouble(string col)
+                        CastleCell GetCell(string col)
                         {
+                            if (!csv.HeaderRecord.Contains(col, StringComparer.OrdinalIgnoreCase))
+                                return new CastleCell(0.0, false);
+
                             string raw = csv.GetField<string>(col);
-                            if (string.IsNullOrWhiteSpace(raw)) return 0.0;
-                            raw = raw.Replace("b", "").Replace("%", "").Trim();
-                            return double.TryParse(raw, NumberStyles.Any, CultureInfo.InvariantCulture, out double result) ? result : 0.0;
+                            if (string.IsNullOrWhiteSpace(raw))
+                                return new CastleCell(0.0, false);
+
+                            bool hasBadMarker = raw.Contains('b', StringComparison.OrdinalIgnoreCase);
+                            raw = raw.Replace("b", "", StringComparison.OrdinalIgnoreCase).Replace("%", "").Trim();
+                            bool parsed = double.TryParse(raw, NumberStyles.Any, CultureInfo.InvariantCulture, out double result);
+                            return new CastleCell(parsed ? result : 0.0, parsed && !hasBadMarker);
                         }
 
-                        double throttleMs = GetDouble("Throttle");
+                        CastleCell throttleCell = GetCell("Throttle");
+                        CastleCell powerOutCell = GetCell("Power-Out");
+                        CastleCell currentCell = GetCell("Current");
+                        CastleCell speedCell = GetCell(rpmField);
+
+                        double throttleMs = throttleCell.Value;
                         double throttlePct = ThrottlePercent.FromMilliseconds(
                             throttleMs, cal.MinMs, cal.NeutralMs, cal.MaxMs);
 
                         var point = new DataPoint
                         {
-                            Time = rowIndex * 0.05,
+                            Time = rowIndex * sampleIntervalSeconds,
                             Throttle = throttleMs,
                             ThrottlePercent = throttlePct,
-                            PowerOut = powerOut,
-                            Voltage = GetDouble("Voltage"),
-                            Ripple = GetDouble("Ripple"),
-                            Current = GetDouble("Current"),
-                            Speed = GetDouble(rpmField),
-                            Temperature = GetDouble("Temperature"),
-                            MotorTemp = GetDouble("Motor Temp."),
-                            MotorTiming = GetDouble("Motor Timing."),
-                            Acceleration = GetDouble("Acceleration.")
+                            PowerOut = powerOutCell.Value,
+                            PowerOutValid = powerOutCell.Valid,
+                            Voltage = GetCell("Voltage").Value,
+                            Ripple = GetCell("Ripple").Value,
+                            Current = currentCell.Value,
+                            CurrentValid = currentCell.Valid,
+                            Speed = speedCell.Value,
+                            SpeedValid = speedCell.Valid,
+                            Temperature = GetCell("Temperature").Value,
+                            MotorTemp = GetCell("Motor Temp.").Value,
+                            MotorTiming = GetCell("Motor Timing.").Value,
+                            Acceleration = GetCell("Acceleration.").Value
                         };
 
                         log?.WriteLine($"Row {rowIndex}: Throttle(ms)={throttleMs:F4}  Throttle(%)={throttlePct:F1}");
@@ -209,16 +215,16 @@ namespace CastleOverlayV2.Services
                 if (runData.DataPoints.Count > 100 &&
                     runData.DataPoints[^1].Time - runData.DataPoints[0].Time > 3.0)
                 {
-                    int launchIndex = DetectDragStartIndex(runData.DataPoints);
-                    Logger.Log($"CsvLoader: LaunchIndex = {launchIndex}");
+                    DragPassDetectionResult detection = DragPassDetector.Detect(runData.DataPoints, sampleIntervalSeconds);
+                    Logger.Log($"CsvLoader: LaunchIndex = {detection.LaunchIndex}; Score = {detection.Score:F2}");
 
-                    if (launchIndex == -1)
+                    if (!detection.Found)
                     {
                         noDragPass = true;
                     }
                     else
                     {
-                        runData.DataPoints = AutoTrim(runData.DataPoints, launchIndex);
+                        runData.DataPoints = AutoTrim(runData.DataPoints, detection);
                         Logger.Log($"CsvLoader: Trimmed count = {runData.DataPoints.Count}");
                         Logger.Log($"CsvLoader: First Point Time = {runData.DataPoints[0].Time:F2}");
                         Logger.Log($"CsvLoader: Last Point Time = {runData.DataPoints[^1].Time:F2}");
@@ -264,74 +270,18 @@ namespace CastleOverlayV2.Services
             public double MaxMs;
         }
 
-        private static int DetectDragStartIndex(List<DataPoint> data)
+        private sealed record CastleCell(double Value, bool Valid);
+
+        private static List<DataPoint> AutoTrim(List<DataPoint> data, DragPassDetectionResult detection)
         {
-            int sustainWindow = 5;
-            for (int i = 1; i < data.Count - sustainWindow; i++)
-            {
-                double prevThrottle = data[i - 1].Throttle;
-                double currThrottle = data[i].Throttle;
-                double currPower = data[i].PowerOut;
-                double currAccel = data[i].Acceleration;
-                double currCurrent = data[i].Current;
-
-                if (prevThrottle <= 1.65 && currThrottle > 1.65)
-                {
-                    bool sustained = true;
-                    for (int k = 0; k < sustainWindow; k++)
-                    {
-                        if (data[i + k].PowerOut < 20.0 || data[i + k].Acceleration < 0.5)
-                        {
-                            sustained = false;
-                            break;
-                        }
-                    }
-                    if (sustained)
-                    {
-                        Logger.Log($"DetectDragStartIndex: Sustained launch detected at row {i}");
-                        return i;
-                    }
-                }
-
-                int triggerScore = 0;
-                if (currPower > 65.0) triggerScore++;
-                if (data[i].Speed > 5000) triggerScore++;
-                if (currAccel > 1.0) triggerScore++;
-                if (currThrottle > 1.7) triggerScore++;
-                if (currCurrent > 5.0) triggerScore++;
-
-                if (triggerScore >= 3)
-                {
-                    bool sustained = true;
-                    for (int k = 0; k < sustainWindow; k++)
-                    {
-                        if (data[i + k].PowerOut < 20.0)
-                        {
-                            sustained = false;
-                            break;
-                        }
-                    }
-                    if (sustained)
-                    {
-                        Logger.Log($"DetectDragStartIndex: Sustained fallback launch detected at row {i}");
-                        return i;
-                    }
-                }
-            }
-            Logger.Log("DetectDragStartIndex: No drag pass detected.");
-            return -1;
-        }
-
-        private static List<DataPoint> AutoTrim(List<DataPoint> data, int index)
-        {
-            if (index == -1 || index >= data.Count)
+            if (!detection.Found || detection.LaunchIndex < 0 || detection.LaunchIndex >= data.Count)
                 return data;
 
-            double t0 = data[index].Time;
-            double tMin = t0 - 0.5;
-            double tMax = t0 + 2.5;
-
-            var trimmed = data.Where(p => p.Time >= tMin && p.Time <= tMax).ToList();
+            double t0 = data[detection.LaunchIndex].Time;
+            var trimmed = data
+                .Skip(detection.TrimStartIndex)
+                .Take(detection.TrimEndIndex - detection.TrimStartIndex + 1)
+                .ToList();
             foreach (var p in trimmed)
                 p.Time -= t0;
 

--- a/src/CastleOverlayV2/Services/DragPassDetector.cs
+++ b/src/CastleOverlayV2/Services/DragPassDetector.cs
@@ -1,0 +1,185 @@
+using CastleOverlayV2.Models;
+
+namespace CastleOverlayV2.Services
+{
+    public sealed record DragPassDetectionResult(
+        bool Found,
+        int LaunchIndex,
+        int TrimStartIndex,
+        int TrimEndIndex,
+        double Score);
+
+    public static class DragPassDetector
+    {
+        private const double PreLaunchSeconds = 0.5;
+        private const double PostLaunchSeconds = 2.5;
+        private const double ScoreWindowSeconds = 2.0;
+
+        public static DragPassDetectionResult Detect(IReadOnlyList<DataPoint> data, double sampleIntervalSeconds)
+        {
+            if (data.Count < 10)
+                return NotFound();
+
+            sampleIntervalSeconds = sampleIntervalSeconds > 0 ? sampleIntervalSeconds : 0.05;
+            int scoreWindow = Math.Max(10, (int)Math.Round(ScoreWindowSeconds / sampleIntervalSeconds));
+            int preLaunchSamples = Math.Max(1, (int)Math.Round(PreLaunchSeconds / sampleIntervalSeconds));
+            int postLaunchSamples = Math.Max(1, (int)Math.Round(PostLaunchSeconds / sampleIntervalSeconds));
+
+            Candidate? best = null;
+            int i = 1;
+            while (i < data.Count - 1)
+            {
+                if (!IsCandidateStart(data, i))
+                {
+                    i++;
+                    continue;
+                }
+
+                int burstStart = i;
+                int burstEnd = i;
+                while (burstEnd + 1 < data.Count && IsLoaded(data[burstEnd + 1]))
+                    burstEnd++;
+
+                Candidate candidate = ScoreCandidate(data, burstStart, burstEnd, scoreWindow);
+                if (candidate.IsViable && (best == null || candidate.Score > best.Score))
+                    best = candidate;
+
+                i = Math.Max(burstEnd + 1, i + 1);
+            }
+
+            if (best == null)
+                return NotFound();
+
+            int launchIndex = FindLaunchAnchor(data, best.StartIndex, preLaunchSamples);
+            int trimStart = Math.Max(0, launchIndex - preLaunchSamples);
+            int trimEnd = Math.Min(data.Count - 1, launchIndex + postLaunchSamples);
+
+            return new DragPassDetectionResult(true, launchIndex, trimStart, trimEnd, best.Score);
+        }
+
+        private static DragPassDetectionResult NotFound() =>
+            new(false, -1, -1, -1, 0);
+
+        private static bool IsCandidateStart(IReadOnlyList<DataPoint> data, int index)
+        {
+            DataPoint previous = data[index - 1];
+            DataPoint current = data[index];
+
+            if (!HasValidLoadSignal(current))
+                return false;
+
+            bool wasIdle = !IsLoaded(previous);
+            bool currentRise = current.CurrentValid && current.Current >= 20.0 &&
+                               (!previous.CurrentValid || current.Current - previous.Current >= 15.0 || previous.Current < 5.0);
+            bool rpmRise = current.SpeedValid && current.Speed >= 5000.0 &&
+                           (!previous.SpeedValid || current.Speed - previous.Speed >= 2500.0 || previous.Speed < 1000.0);
+            bool powerRise = current.PowerOutValid && current.PowerOut >= 20.0 &&
+                             (!previous.PowerOutValid || current.PowerOut - previous.PowerOut >= 15.0 || previous.PowerOut < 5.0);
+            bool throttleMove = current.Throttle > 1.62 && previous.Throttle <= 1.62;
+
+            return wasIdle || currentRise || rpmRise || powerRise || throttleMove;
+        }
+
+        private static bool IsLoaded(DataPoint point) =>
+            (point.CurrentValid && point.Current >= 8.0) ||
+            (point.PowerOutValid && point.PowerOut >= 18.0) ||
+            (point.SpeedValid && point.Speed >= 4000.0);
+
+        private static bool HasValidLoadSignal(DataPoint point) =>
+            (point.CurrentValid && point.Current >= 15.0) ||
+            (point.PowerOutValid && point.PowerOut >= 25.0) ||
+            (point.SpeedValid && point.Speed >= 7000.0);
+
+        private static Candidate ScoreCandidate(
+            IReadOnlyList<DataPoint> data,
+            int startIndex,
+            int burstEndIndex,
+            int scoreWindow)
+        {
+            int endIndex = Math.Min(data.Count - 1, startIndex + scoreWindow);
+            double peakCurrent = 0;
+            double currentArea = 0;
+            double peakPower = 0;
+            double powerArea = 0;
+            double startRpm = data[startIndex].SpeedValid ? data[startIndex].Speed : 0;
+            double peakRpm = startRpm;
+            int loadedSamples = 0;
+            int highPowerSamples = 0;
+
+            for (int i = startIndex; i <= endIndex; i++)
+            {
+                DataPoint point = data[i];
+
+                if (point.CurrentValid)
+                {
+                    peakCurrent = Math.Max(peakCurrent, point.Current);
+                    currentArea += Math.Max(0, point.Current);
+                }
+
+                if (point.PowerOutValid)
+                {
+                    peakPower = Math.Max(peakPower, point.PowerOut);
+                    powerArea += Math.Max(0, point.PowerOut);
+                    if (point.PowerOut >= 40.0)
+                        highPowerSamples++;
+                }
+
+                if (point.SpeedValid)
+                    peakRpm = Math.Max(peakRpm, point.Speed);
+
+                if (IsLoaded(point))
+                    loadedSamples++;
+            }
+
+            double rpmRise = Math.Max(0, peakRpm - startRpm);
+            double score =
+                peakCurrent * 4.0 +
+                currentArea * 0.35 +
+                peakPower * 12.0 +
+                powerArea * 0.12 +
+                rpmRise * 0.01 +
+                loadedSamples * 25.0 +
+                highPowerSamples * 30.0;
+
+            bool viable =
+                peakCurrent >= 300.0 &&
+                peakPower >= 75.0 &&
+                peakRpm >= 40000.0 &&
+                loadedSamples >= 8;
+
+            return new Candidate(startIndex, burstEndIndex, score, viable);
+        }
+
+        private static int FindLaunchAnchor(IReadOnlyList<DataPoint> data, int startIndex, int preLaunchSamples)
+        {
+            int searchStart = Math.Max(1, startIndex - preLaunchSamples);
+            int anchor = startIndex;
+
+            for (int i = searchStart; i <= startIndex; i++)
+            {
+                DataPoint previous = data[i - 1];
+                DataPoint current = data[i];
+
+                bool previousIdle =
+                    (!previous.CurrentValid || previous.Current <= 5.0) &&
+                    (!previous.SpeedValid || previous.Speed <= 1500.0) &&
+                    (!previous.PowerOutValid || previous.PowerOut <= 10.0);
+
+                bool currentLoaded =
+                    (current.CurrentValid && current.Current >= 10.0) ||
+                    (current.SpeedValid && current.Speed >= 2500.0) ||
+                    (current.PowerOutValid && current.PowerOut >= 20.0);
+
+                if (previousIdle && currentLoaded)
+                {
+                    anchor = i;
+                    break;
+                }
+            }
+
+            return anchor;
+        }
+
+        private sealed record Candidate(int StartIndex, int EndIndex, double Score, bool IsViable);
+    }
+}


### PR DESCRIPTION
## Summary

- parse the complete first Castle session before trimming so genuine pre-launch samples remain available
- read the Castle `Sample Time` metadata instead of assuming 50 ms
- preserve validity of `b`-marked power/current/RPM values so invalid samples cannot strengthen launch detection
- replace first-match launch detection with scored drag-burst candidate selection
- accept valid launches with negative acceleration
- retain the `-0.5s` to `+2.5s` product window and re-zero the selected launch
- stop cleanly when a repeated Castle metadata/header block begins instead of merging sessions

## Verification

- `dotnet build src/CastleOverlayV2/CastleOverlayV2.csproj -c Release`
- `dotnet test Tests/CastleOverlayV2.Tests/CastleOverlayV2.Tests.csproj -c Release`
- isolated result: 23/23 tests passed
- locally validated against the seven supplied original/manual log pairs; raw multi-megabyte logs were intentionally not committed

## Notes

Existing OpenTK compatibility and nullable/obsolete API warnings remain unchanged.