### PR TITLE
feat: define .dragoverlay project format v1

### DIFF
--- a/Docs/PROJECT_FORMAT_V1.md
+++ b/Docs/PROJECT_FORMAT_V1.md
@@ -1,0 +1,99 @@
+# DragOverlay project format v1
+
+DragOverlay project files use the `.dragoverlay` extension and are ZIP packages. Version 1 stores original input files without modification so later DragOverlay versions can reparse them using improved loaders.
+
+Issue #85 defines the manifest only. ZIP save/load behavior is implemented separately.
+
+## Package layout
+
+```text
+project.dragoverlay
+├─ project.json
+├─ logs/
+│  ├─ castle-slot-1.csv
+│  └─ racebox-slot-1.csv
+└─ tunes/
+   └─ castle-slot-1.dat
+```
+
+Package paths:
+
+- are relative to the package root;
+- use `/` separators;
+- cannot contain empty, `.` or `..` segments;
+- cannot be absolute paths, drive-qualified paths, or backslash paths;
+- use stable slot-based names to avoid collisions.
+
+## Manifest
+
+`project.json` is UTF-8 JSON. The current schema version is defined by `ProjectFormat.CurrentSchemaVersion`.
+
+Unknown JSON properties are ignored for forward compatibility. A schema version newer than the application supports is rejected as `UnsupportedVersion`; it is not silently treated as version 1.
+
+The manifest records:
+
+- application build and UTC creation time;
+- Drag or Speed mode;
+- channel visibility;
+- every occupied Castle and RaceBox slot;
+- original display filename and package source path;
+- run visibility and time-shift offset in milliseconds;
+- optional Castle tune path;
+- manual controller-style radio settings.
+
+Castle UI slots 1–3 use plot slots 1–3. RaceBox UI slots 1–3 use plot slots 4–6.
+
+## Example `project.json`
+
+```json
+{
+  "schemaVersion": 1,
+  "appBuild": "1.13",
+  "createdUtc": "2026-06-20T02:00:00+00:00",
+  "runMode": "Drag",
+  "channelVisibility": {
+    "RPM": true,
+    "Throttle %": true,
+    "RaceBox Speed": false
+  },
+  "runs": [
+    {
+      "sourceType": "Castle",
+      "uiSlot": 1,
+      "plotSlot": 1,
+      "displayFileName": "castle-run.csv",
+      "sourcePath": "logs/castle-slot-1.csv",
+      "isVisible": true,
+      "timeShiftMs": 42.5,
+      "tunePath": "tunes/castle-slot-1.dat",
+      "radioSettings": {
+        "profileName": "Race",
+        "throttleSpeedMode": "Mode 3",
+        "mode": 3,
+        "speedType": "Normal",
+        "highTurnPercent": 68,
+        "highReturnPercent": 100,
+        "point2Percent": 60,
+        "middleTurnPercent": 36,
+        "middleReturnPercent": 100,
+        "point1Percent": 19,
+        "lowTurnPercent": 100,
+        "lowReturnPercent": 100
+      }
+    },
+    {
+      "sourceType": "RaceBox",
+      "uiSlot": 1,
+      "plotSlot": 4,
+      "displayFileName": "racebox-run.csv",
+      "sourcePath": "logs/racebox-slot-1.csv",
+      "isVisible": false,
+      "timeShiftMs": -15.0
+    }
+  ]
+}
+```
+
+## Version 1 exclusions
+
+Version 1 does not require derived plot data, parsed telemetry caches, screenshots, or original absolute disk paths.

--- a/Tests/CastleOverlayV2.Tests/ProjectManifestTests.cs
+++ b/Tests/CastleOverlayV2.Tests/ProjectManifestTests.cs
@@ -1,0 +1,164 @@
+using CastleOverlayV2.Models;
+using CastleOverlayV2.Services;
+using Newtonsoft.Json.Linq;
+
+namespace CastleOverlayV2.Tests;
+
+public sealed class ProjectManifestTests
+{
+    [Fact]
+    public void Manifest_RoundTrips_AllVersionOneState()
+    {
+        var manifest = CreateManifest();
+        var json = new ProjectManifestJson();
+
+        string text = json.Serialize(manifest);
+        ProjectManifestLoadResult result = json.Deserialize(text);
+
+        Assert.True(result.IsSuccess, string.Join(Environment.NewLine, result.Errors));
+        ProjectManifest loaded = Assert.IsType<ProjectManifest>(result.Manifest);
+        Assert.Equal(ProjectFormat.CurrentSchemaVersion, loaded.SchemaVersion);
+        Assert.Equal(ProjectRunMode.Drag, loaded.RunMode);
+        Assert.False(loaded.ChannelVisibility["RPM"]);
+        Assert.Equal(2, loaded.Runs.Count);
+
+        ProjectRunEntry castle = loaded.Runs[0];
+        Assert.Equal(ProjectSourceType.Castle, castle.SourceType);
+        Assert.Equal(1, castle.UiSlot);
+        Assert.Equal(1, castle.PlotSlot);
+        Assert.Equal("tunes/castle-slot-1.dat", castle.TunePath);
+        Assert.Equal(42.5, castle.TimeShiftMs);
+        Assert.Equal(3, castle.RadioSettings?.Mode);
+        Assert.Equal(60, castle.RadioSettings?.Point2Percent);
+
+        ProjectRunEntry raceBox = loaded.Runs[1];
+        Assert.Equal(ProjectSourceType.RaceBox, raceBox.SourceType);
+        Assert.Equal(1, raceBox.UiSlot);
+        Assert.Equal(4, raceBox.PlotSlot);
+        Assert.False(raceBox.IsVisible);
+    }
+
+    [Fact]
+    public void Deserialize_IgnoresUnknownFutureProperties()
+    {
+        var json = new ProjectManifestJson();
+        JObject document = JObject.Parse(json.Serialize(CreateManifest()));
+        document["futureSetting"] = "ignored";
+        ((JObject)document["runs"]![0]!)["futureRunSetting"] = 123;
+
+        ProjectManifestLoadResult result = json.Deserialize(document.ToString());
+
+        Assert.True(result.IsSuccess, string.Join(Environment.NewLine, result.Errors));
+        Assert.Equal(2, result.Manifest?.Runs.Count);
+    }
+
+    [Fact]
+    public void Deserialize_ReturnsUnsupportedVersionResult()
+    {
+        JObject document = JObject.Parse(new ProjectManifestJson().Serialize(CreateManifest()));
+        document["schemaVersion"] = ProjectFormat.CurrentSchemaVersion + 1;
+
+        ProjectManifestLoadResult result =
+            new ProjectManifestJson().Deserialize(document.ToString());
+
+        Assert.Equal(ProjectManifestLoadStatus.UnsupportedVersion, result.Status);
+        Assert.Contains(result.Errors, error => error.Contains("newer than", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData(@"C:\logs\run.csv")]
+    [InlineData("/logs/run.csv")]
+    [InlineData("../run.csv")]
+    [InlineData("logs/../run.csv")]
+    [InlineData(@"logs\run.csv")]
+    [InlineData("logs//run.csv")]
+    public void Validator_RejectsUnsafePackagePaths(string path)
+    {
+        ProjectManifest manifest = CreateManifest();
+        manifest.Runs[0].SourcePath = path;
+
+        ProjectManifestValidationResult result =
+            new ProjectManifestValidator().Validate(manifest);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, error => error.Contains("SourcePath", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validator_RejectsInvalidSlotMappingAndSourceTypeRules()
+    {
+        ProjectManifest manifest = CreateManifest();
+        manifest.Runs[1].PlotSlot = 1;
+        manifest.Runs[1].TunePath = "tunes/racebox-slot-1.dat";
+
+        ProjectManifestValidationResult result =
+            new ProjectManifestValidator().Validate(manifest);
+
+        Assert.Contains(result.Errors, error => error.Contains("PlotSlot must be 4", StringComparison.Ordinal));
+        Assert.Contains(result.Errors, error => error.Contains("only valid for Castle", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Serialize_RejectsInvalidManifest()
+    {
+        ProjectManifest manifest = CreateManifest();
+        manifest.AppBuild = "";
+
+        ProjectManifestException exception = Assert.Throws<ProjectManifestException>(
+            () => new ProjectManifestJson().Serialize(manifest));
+
+        Assert.Contains(exception.Errors, error => error.Contains("AppBuild", StringComparison.Ordinal));
+    }
+
+    private static ProjectManifest CreateManifest() => new()
+    {
+        AppBuild = "1.13",
+        CreatedUtc = new DateTimeOffset(2026, 6, 20, 2, 0, 0, TimeSpan.Zero),
+        RunMode = ProjectRunMode.Drag,
+        ChannelVisibility = new Dictionary<string, bool>
+        {
+            ["RPM"] = false,
+            ["Throttle %"] = true,
+            ["RaceBox Speed"] = true
+        },
+        Runs =
+        {
+            new ProjectRunEntry
+            {
+                SourceType = ProjectSourceType.Castle,
+                UiSlot = 1,
+                PlotSlot = 1,
+                DisplayFileName = "castle run.csv",
+                SourcePath = "logs/castle-slot-1.csv",
+                IsVisible = true,
+                TimeShiftMs = 42.5,
+                TunePath = "tunes/castle-slot-1.dat",
+                RadioSettings = new RadioTuneSettings
+                {
+                    ProfileName = "Race",
+                    ThrottleSpeedMode = "Mode 3",
+                    Mode = 3,
+                    SpeedType = "Normal",
+                    HighTurnPercent = 68,
+                    HighReturnPercent = 100,
+                    Point2Percent = 60,
+                    MiddleTurnPercent = 36,
+                    MiddleReturnPercent = 100,
+                    Point1Percent = 19,
+                    LowTurnPercent = 100,
+                    LowReturnPercent = 100
+                }
+            },
+            new ProjectRunEntry
+            {
+                SourceType = ProjectSourceType.RaceBox,
+                UiSlot = 1,
+                PlotSlot = 4,
+                DisplayFileName = "racebox run.csv",
+                SourcePath = "logs/racebox-slot-1.csv",
+                IsVisible = false,
+                TimeShiftMs = -15
+            }
+        }
+    };
+}

--- a/src/CastleOverlayV2/Models/ProjectFormat.cs
+++ b/src/CastleOverlayV2/Models/ProjectFormat.cs
@@ -1,0 +1,9 @@
+namespace CastleOverlayV2.Models
+{
+    public static class ProjectFormat
+    {
+        public const int CurrentSchemaVersion = 1;
+        public const string ManifestFileName = "project.json";
+        public const string FileExtension = ".dragoverlay";
+    }
+}

--- a/src/CastleOverlayV2/Models/ProjectManifest.cs
+++ b/src/CastleOverlayV2/Models/ProjectManifest.cs
@@ -1,0 +1,38 @@
+namespace CastleOverlayV2.Models
+{
+    public sealed class ProjectManifest
+    {
+        public int SchemaVersion { get; set; } = ProjectFormat.CurrentSchemaVersion;
+        public string AppBuild { get; set; } = "";
+        public DateTimeOffset CreatedUtc { get; set; } = DateTimeOffset.UtcNow;
+        public ProjectRunMode RunMode { get; set; } = ProjectRunMode.Drag;
+        public Dictionary<string, bool> ChannelVisibility { get; set; } =
+            new(StringComparer.OrdinalIgnoreCase);
+        public List<ProjectRunEntry> Runs { get; set; } = new();
+    }
+
+    public sealed class ProjectRunEntry
+    {
+        public ProjectSourceType SourceType { get; set; }
+        public int UiSlot { get; set; }
+        public int PlotSlot { get; set; }
+        public string DisplayFileName { get; set; } = "";
+        public string SourcePath { get; set; } = "";
+        public bool IsVisible { get; set; } = true;
+        public double TimeShiftMs { get; set; }
+        public string? TunePath { get; set; }
+        public RadioTuneSettings? RadioSettings { get; set; }
+    }
+
+    public enum ProjectRunMode
+    {
+        Drag,
+        Speed
+    }
+
+    public enum ProjectSourceType
+    {
+        Castle,
+        RaceBox
+    }
+}

--- a/src/CastleOverlayV2/Services/ProjectManifestJson.cs
+++ b/src/CastleOverlayV2/Services/ProjectManifestJson.cs
@@ -1,0 +1,102 @@
+using CastleOverlayV2.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+
+namespace CastleOverlayV2.Services
+{
+    public sealed class ProjectManifestJson
+    {
+        private static readonly JsonSerializerSettings Settings = new()
+        {
+            Formatting = Formatting.Indented,
+            MissingMemberHandling = MissingMemberHandling.Ignore,
+            NullValueHandling = NullValueHandling.Ignore,
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            Converters = { new StringEnumConverter() }
+        };
+
+        private readonly ProjectManifestValidator _validator = new();
+
+        public string Serialize(ProjectManifest manifest)
+        {
+            ProjectManifestValidationResult validation = _validator.Validate(manifest);
+            if (!validation.IsValid)
+                throw new ProjectManifestException(validation.Errors);
+
+            return JsonConvert.SerializeObject(manifest, Settings);
+        }
+
+        public ProjectManifestLoadResult Deserialize(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+                return ProjectManifestLoadResult.Invalid("The project manifest is empty.");
+
+            try
+            {
+                ProjectManifest? manifest = JsonConvert.DeserializeObject<ProjectManifest>(json, Settings);
+                ProjectManifestValidationResult validation = _validator.Validate(manifest);
+                if (!validation.IsValid)
+                {
+                    return validation.IsUnsupportedVersion
+                        ? ProjectManifestLoadResult.Unsupported(validation.Errors)
+                        : ProjectManifestLoadResult.Invalid(validation.Errors);
+                }
+
+                return ProjectManifestLoadResult.Success(manifest!);
+            }
+            catch (JsonException ex)
+            {
+                return ProjectManifestLoadResult.Invalid($"The project manifest JSON is invalid: {ex.Message}");
+            }
+        }
+    }
+
+    public sealed class ProjectManifestLoadResult
+    {
+        private ProjectManifestLoadResult(
+            ProjectManifest? manifest,
+            ProjectManifestLoadStatus status,
+            IReadOnlyList<string> errors)
+        {
+            Manifest = manifest;
+            Status = status;
+            Errors = errors;
+        }
+
+        public ProjectManifest? Manifest { get; }
+        public ProjectManifestLoadStatus Status { get; }
+        public IReadOnlyList<string> Errors { get; }
+        public bool IsSuccess => Status == ProjectManifestLoadStatus.Success;
+
+        public static ProjectManifestLoadResult Success(ProjectManifest manifest) =>
+            new(manifest, ProjectManifestLoadStatus.Success, Array.Empty<string>());
+
+        public static ProjectManifestLoadResult Invalid(params string[] errors) =>
+            Invalid((IReadOnlyList<string>)errors);
+
+        public static ProjectManifestLoadResult Invalid(IReadOnlyList<string> errors) =>
+            new(null, ProjectManifestLoadStatus.Invalid, errors);
+
+        public static ProjectManifestLoadResult Unsupported(IReadOnlyList<string> errors) =>
+            new(null, ProjectManifestLoadStatus.UnsupportedVersion, errors);
+    }
+
+    public enum ProjectManifestLoadStatus
+    {
+        Success,
+        Invalid,
+        UnsupportedVersion
+    }
+
+    public sealed class ProjectManifestException : Exception
+    {
+        public ProjectManifestException(IReadOnlyList<string> errors)
+            : base(string.Join(Environment.NewLine, errors))
+        {
+            Errors = errors;
+        }
+
+        public IReadOnlyList<string> Errors { get; }
+    }
+}

--- a/src/CastleOverlayV2/Services/ProjectManifestValidator.cs
+++ b/src/CastleOverlayV2/Services/ProjectManifestValidator.cs
@@ -1,0 +1,165 @@
+using CastleOverlayV2.Models;
+
+namespace CastleOverlayV2.Services
+{
+    public sealed class ProjectManifestValidator
+    {
+        public ProjectManifestValidationResult Validate(ProjectManifest? manifest)
+        {
+            var errors = new List<string>();
+            if (manifest == null)
+            {
+                errors.Add("The project manifest is missing.");
+                return new ProjectManifestValidationResult(errors);
+            }
+
+            if (manifest.SchemaVersion > ProjectFormat.CurrentSchemaVersion)
+            {
+                errors.Add(
+                    $"Project schema version {manifest.SchemaVersion} is newer than the supported version " +
+                    $"{ProjectFormat.CurrentSchemaVersion}.");
+                return new ProjectManifestValidationResult(errors, isUnsupportedVersion: true);
+            }
+
+            if (manifest.SchemaVersion < 1)
+                errors.Add("SchemaVersion must be 1 or greater.");
+            if (string.IsNullOrWhiteSpace(manifest.AppBuild))
+                errors.Add("AppBuild is required.");
+            if (manifest.CreatedUtc == default)
+                errors.Add("CreatedUtc is required.");
+            if (!Enum.IsDefined(manifest.RunMode))
+                errors.Add($"RunMode '{manifest.RunMode}' is not supported.");
+            if (manifest.ChannelVisibility == null)
+                errors.Add("ChannelVisibility is required.");
+            if (manifest.Runs == null)
+            {
+                errors.Add("Runs is required.");
+                return new ProjectManifestValidationResult(errors);
+            }
+
+            var plotSlots = new HashSet<int>();
+            var sourcePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (int index = 0; index < manifest.Runs.Count; index++)
+            {
+                ProjectRunEntry? run = manifest.Runs[index];
+                string prefix = $"Runs[{index}]";
+                if (run == null)
+                {
+                    errors.Add($"{prefix} is missing.");
+                    continue;
+                }
+
+                ValidateRun(run, prefix, errors);
+                if (!plotSlots.Add(run.PlotSlot))
+                    errors.Add($"{prefix}.PlotSlot duplicates plot slot {run.PlotSlot}.");
+                if (!string.IsNullOrWhiteSpace(run.SourcePath) && !sourcePaths.Add(run.SourcePath))
+                    errors.Add($"{prefix}.SourcePath duplicates '{run.SourcePath}'.");
+            }
+
+            return new ProjectManifestValidationResult(errors);
+        }
+
+        public static bool IsSafePackagePath(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path) ||
+                Path.IsPathRooted(path) ||
+                path.StartsWith('/') ||
+                path.Contains('\\') ||
+                path.Contains(':'))
+            {
+                return false;
+            }
+
+            string[] segments = path.Split('/');
+            return segments.All(segment =>
+                !string.IsNullOrWhiteSpace(segment) &&
+                segment != "." &&
+                segment != "..");
+        }
+
+        private static void ValidateRun(
+            ProjectRunEntry run,
+            string prefix,
+            ICollection<string> errors)
+        {
+            if (!Enum.IsDefined(run.SourceType))
+                errors.Add($"{prefix}.SourceType is not supported.");
+            if (run.UiSlot is < 1 or > 3)
+                errors.Add($"{prefix}.UiSlot must be between 1 and 3.");
+
+            int expectedPlotSlot = run.SourceType == ProjectSourceType.RaceBox
+                ? run.UiSlot + 3
+                : run.UiSlot;
+            if (run.PlotSlot != expectedPlotSlot)
+            {
+                errors.Add(
+                    $"{prefix}.PlotSlot must be {expectedPlotSlot} for {run.SourceType} UI slot {run.UiSlot}.");
+            }
+
+            if (string.IsNullOrWhiteSpace(run.DisplayFileName))
+                errors.Add($"{prefix}.DisplayFileName is required.");
+            if (!IsSafePackagePath(run.SourcePath))
+                errors.Add($"{prefix}.SourcePath must be a safe package-relative path using forward slashes.");
+            if (!string.IsNullOrWhiteSpace(run.TunePath) && !IsSafePackagePath(run.TunePath))
+                errors.Add($"{prefix}.TunePath must be a safe package-relative path using forward slashes.");
+            if (run.SourceType == ProjectSourceType.RaceBox && !string.IsNullOrWhiteSpace(run.TunePath))
+                errors.Add($"{prefix}.TunePath is only valid for Castle runs.");
+            if (double.IsNaN(run.TimeShiftMs) || double.IsInfinity(run.TimeShiftMs))
+                errors.Add($"{prefix}.TimeShiftMs must be a finite number.");
+
+            ValidateRadio(run.RadioSettings, $"{prefix}.RadioSettings", errors);
+        }
+
+        private static void ValidateRadio(
+            RadioTuneSettings? radio,
+            string prefix,
+            ICollection<string> errors)
+        {
+            if (radio == null)
+                return;
+
+            if (radio.Mode is < 1 or > 3)
+                errors.Add($"{prefix}.Mode must be between 1 and 3.");
+
+            foreach ((string name, double? value) in GetRadioValues(radio))
+            {
+                if (value.HasValue &&
+                    (double.IsNaN(value.Value) ||
+                     double.IsInfinity(value.Value) ||
+                     value.Value is < 1 or > 100))
+                {
+                    errors.Add($"{prefix}.{name} must be between 1 and 100.");
+                }
+            }
+        }
+
+        private static IEnumerable<(string Name, double? Value)> GetRadioValues(RadioTuneSettings radio)
+        {
+            yield return (nameof(radio.AllTurnPercent), radio.AllTurnPercent);
+            yield return (nameof(radio.AllReturnPercent), radio.AllReturnPercent);
+            yield return (nameof(radio.HighTurnPercent), radio.HighTurnPercent);
+            yield return (nameof(radio.HighReturnPercent), radio.HighReturnPercent);
+            yield return (nameof(radio.MiddleTurnPercent), radio.MiddleTurnPercent);
+            yield return (nameof(radio.MiddleReturnPercent), radio.MiddleReturnPercent);
+            yield return (nameof(radio.LowTurnPercent), radio.LowTurnPercent);
+            yield return (nameof(radio.LowReturnPercent), radio.LowReturnPercent);
+            yield return (nameof(radio.Point1Percent), radio.Point1Percent);
+            yield return (nameof(radio.Point2Percent), radio.Point2Percent);
+        }
+    }
+
+    public sealed class ProjectManifestValidationResult
+    {
+        public ProjectManifestValidationResult(
+            IReadOnlyList<string> errors,
+            bool isUnsupportedVersion = false)
+        {
+            Errors = errors;
+            IsUnsupportedVersion = isUnsupportedVersion;
+        }
+
+        public bool IsValid => Errors.Count == 0;
+        public bool IsUnsupportedVersion { get; }
+        public IReadOnlyList<string> Errors { get; }
+    }
+}


### PR DESCRIPTION
## Summary
- define the version 1 `.dragoverlay` manifest and run-entry models
- serialize readable camelCase JSON with string enums using the existing Newtonsoft.Json dependency
- validate schema versions, Castle/RaceBox slot mappings, required metadata, radio values, and safe package-relative paths
- document the ZIP package layout and representative `project.json`
- add round-trip, compatibility, version, slot, and path validation tests

## Why
Save/load needs a stable, versioned contract before package I/O is implemented. This keeps original source files portable, makes future schema changes explicit, and prevents unsafe package paths from reaching later ZIP extraction code.

## Scope
This PR intentionally contains no ZIP reading/writing and no UI changes. Those remain in issues #86�#88.

## Validation
- `dotnet build src/CastleOverlayV2/CastleOverlayV2.csproj -c Release`
- `dotnet test Tests/CastleOverlayV2.Tests/CastleOverlayV2.Tests.csproj -c Release --no-restore` (33 passed)

Closes #85
