### PR TITLE
feat: save complete session as a .dragoverlay package (closes #86)

### DIFF
--- a/Tests/CastleOverlayV2.Tests/ProjectSaverTests.cs
+++ b/Tests/CastleOverlayV2.Tests/ProjectSaverTests.cs
@@ -1,0 +1,371 @@
+using CastleOverlayV2.Models;
+using CastleOverlayV2.Services;
+using System.IO.Compression;
+using System.Text;
+
+namespace CastleOverlayV2.Tests;
+
+public sealed class ProjectSaverTests : IDisposable
+{
+    private readonly string _workDir;
+
+    public ProjectSaverTests()
+    {
+        _workDir = Path.Combine(Path.GetTempPath(),
+            "DragOverlayTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_workDir);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_workDir))
+                Directory.Delete(_workDir, recursive: true);
+        }
+        catch
+        {
+            // best effort
+        }
+    }
+
+    [Fact]
+    public void Save_WritesPackage_For_CastleOnly_Session()
+    {
+        var castleBytes = SyntheticBytes("castle-1");
+        string castleCsvPath = WriteFile("castle-original.csv", castleBytes);
+
+        var snapshot = new ProjectSnapshot
+        {
+            Manifest = BaseManifest(new ProjectRunEntry
+            {
+                SourceType = ProjectSourceType.Castle,
+                UiSlot = 1,
+                PlotSlot = 1,
+                DisplayFileName = "castle-original.csv",
+                SourcePath = "logs/castle-1.csv",
+                IsVisible = true,
+                TimeShiftMs = 0
+            }),
+            Files = new[]
+            {
+                new ProjectSnapshotFile(castleCsvPath, "logs/castle-1.csv")
+            }
+        };
+
+        string dest = Path.Combine(_workDir, "session.dragoverlay");
+        var result = new ProjectSaver().Save(dest, snapshot);
+
+        Assert.True(result.Ok, result.Message);
+        Assert.Equal(dest, result.Value);
+        Assert.True(File.Exists(dest));
+
+        using var archive = ZipFile.OpenRead(dest);
+        Assert.NotNull(archive.GetEntry("project.json"));
+        var entry = Assert.IsAssignableFrom<ZipArchiveEntry>(archive.GetEntry("logs/castle-1.csv"));
+        Assert.Equal(castleBytes, ReadEntryBytes(entry));
+    }
+
+    [Fact]
+    public void Save_WritesPackage_For_RaceBoxOnly_Session()
+    {
+        var raceboxBytes = SyntheticBytes("racebox-1");
+        string raceboxCsvPath = WriteFile("racebox.csv", raceboxBytes);
+
+        var snapshot = new ProjectSnapshot
+        {
+            Manifest = BaseManifest(new ProjectRunEntry
+            {
+                SourceType = ProjectSourceType.RaceBox,
+                UiSlot = 1,
+                PlotSlot = 4,
+                DisplayFileName = "racebox.csv",
+                SourcePath = "logs/racebox-1.csv",
+                IsVisible = true,
+                TimeShiftMs = 0
+            }),
+            Files = new[]
+            {
+                new ProjectSnapshotFile(raceboxCsvPath, "logs/racebox-1.csv")
+            }
+        };
+
+        string dest = Path.Combine(_workDir, "racebox-only.dragoverlay");
+        var result = new ProjectSaver().Save(dest, snapshot);
+
+        Assert.True(result.Ok, result.Message);
+        using var archive = ZipFile.OpenRead(dest);
+        Assert.NotNull(archive.GetEntry("project.json"));
+        Assert.NotNull(archive.GetEntry("logs/racebox-1.csv"));
+    }
+
+    [Fact]
+    public void Save_WritesPackage_For_Mixed_Session_WithTune()
+    {
+        var castleBytes = SyntheticBytes("castle-mixed");
+        var raceboxBytes = SyntheticBytes("racebox-mixed");
+        var tuneBytes = SyntheticBytes("tune-mixed");
+
+        string castlePath = WriteFile("c.csv", castleBytes);
+        string raceboxPath = WriteFile("rb.csv", raceboxBytes);
+        string tunePath = WriteFile("t.dat", tuneBytes);
+
+        var snapshot = new ProjectSnapshot
+        {
+            Manifest = BaseManifest(
+                new ProjectRunEntry
+                {
+                    SourceType = ProjectSourceType.Castle,
+                    UiSlot = 1,
+                    PlotSlot = 1,
+                    DisplayFileName = "c.csv",
+                    SourcePath = "logs/castle-1.csv",
+                    IsVisible = true,
+                    TimeShiftMs = 25.0,
+                    TunePath = "tunes/castle-1.dat",
+                    RadioSettings = new RadioTuneSettings { Mode = 2, Point1Percent = 30, Point2Percent = 70 }
+                },
+                new ProjectRunEntry
+                {
+                    SourceType = ProjectSourceType.RaceBox,
+                    UiSlot = 1,
+                    PlotSlot = 4,
+                    DisplayFileName = "rb.csv",
+                    SourcePath = "logs/racebox-1.csv",
+                    IsVisible = false,
+                    TimeShiftMs = -10.0
+                }),
+            Files = new[]
+            {
+                new ProjectSnapshotFile(castlePath, "logs/castle-1.csv"),
+                new ProjectSnapshotFile(raceboxPath, "logs/racebox-1.csv"),
+                new ProjectSnapshotFile(tunePath, "tunes/castle-1.dat")
+            }
+        };
+
+        string dest = Path.Combine(_workDir, "mixed.dragoverlay");
+        var result = new ProjectSaver().Save(dest, snapshot);
+
+        Assert.True(result.Ok, result.Message);
+        using var archive = ZipFile.OpenRead(dest);
+
+        // Source bytes preserved verbatim.
+        Assert.Equal(castleBytes, ReadEntryBytes(archive.GetEntry("logs/castle-1.csv")!));
+        Assert.Equal(raceboxBytes, ReadEntryBytes(archive.GetEntry("logs/racebox-1.csv")!));
+        Assert.Equal(tuneBytes, ReadEntryBytes(archive.GetEntry("tunes/castle-1.dat")!));
+
+        // Manifest round-trips and includes the radio settings + offsets.
+        string manifestJson;
+        using (var ms = new MemoryStream())
+        {
+            archive.GetEntry("project.json")!.Open().CopyTo(ms);
+            manifestJson = Encoding.UTF8.GetString(ms.ToArray());
+        }
+        var loaded = new ProjectManifestJson().Deserialize(manifestJson);
+        Assert.True(loaded.IsSuccess, string.Join(Environment.NewLine, loaded.Errors));
+        Assert.Equal(2, loaded.Manifest!.Runs.Count);
+        Assert.Equal(25.0, loaded.Manifest.Runs[0].TimeShiftMs);
+        Assert.Equal(2, loaded.Manifest.Runs[0].RadioSettings?.Mode);
+        Assert.Equal(-10.0, loaded.Manifest.Runs[1].TimeShiftMs);
+        Assert.False(loaded.Manifest.Runs[1].IsVisible);
+    }
+
+    [Fact]
+    public void Save_ReplacesExistingDestination()
+    {
+        var bytes = SyntheticBytes("replace-test");
+        string srcPath = WriteFile("c.csv", bytes);
+        string dest = Path.Combine(_workDir, "exists.dragoverlay");
+
+        // Pre-existing destination with different content.
+        File.WriteAllText(dest, "not a zip");
+
+        var snapshot = new ProjectSnapshot
+        {
+            Manifest = BaseManifest(new ProjectRunEntry
+            {
+                SourceType = ProjectSourceType.Castle,
+                UiSlot = 1,
+                PlotSlot = 1,
+                DisplayFileName = "c.csv",
+                SourcePath = "logs/castle-1.csv",
+                IsVisible = true
+            }),
+            Files = new[] { new ProjectSnapshotFile(srcPath, "logs/castle-1.csv") }
+        };
+
+        var result = new ProjectSaver().Save(dest, snapshot);
+
+        Assert.True(result.Ok, result.Message);
+        using var archive = ZipFile.OpenRead(dest);
+        Assert.NotNull(archive.GetEntry("project.json"));
+    }
+
+    [Fact]
+    public void Save_DoesNotLeavePartialFile_WhenSourceMissing()
+    {
+        string dest = Path.Combine(_workDir, "wont-exist.dragoverlay");
+
+        var snapshot = new ProjectSnapshot
+        {
+            Manifest = BaseManifest(new ProjectRunEntry
+            {
+                SourceType = ProjectSourceType.Castle,
+                UiSlot = 1,
+                PlotSlot = 1,
+                DisplayFileName = "missing.csv",
+                SourcePath = "logs/castle-1.csv",
+                IsVisible = true
+            }),
+            Files = new[]
+            {
+                new ProjectSnapshotFile(
+                    Path.Combine(_workDir, "this-file-does-not-exist.csv"),
+                    "logs/castle-1.csv")
+            }
+        };
+
+        var result = new ProjectSaver().Save(dest, snapshot);
+
+        Assert.False(result.Ok);
+        Assert.False(File.Exists(dest));
+        // No leftover temp files.
+        Assert.Empty(Directory.GetFiles(_workDir, "*.tmp"));
+    }
+
+    [Fact]
+    public void Save_RejectsDuplicateArchivePaths()
+    {
+        string srcA = WriteFile("a.csv", SyntheticBytes("a"));
+        string srcB = WriteFile("b.csv", SyntheticBytes("b"));
+
+        var snapshot = new ProjectSnapshot
+        {
+            Manifest = BaseManifest(new ProjectRunEntry
+            {
+                SourceType = ProjectSourceType.Castle,
+                UiSlot = 1,
+                PlotSlot = 1,
+                DisplayFileName = "a.csv",
+                SourcePath = "logs/dup.csv",
+                IsVisible = true
+            }),
+            Files = new[]
+            {
+                new ProjectSnapshotFile(srcA, "logs/dup.csv"),
+                new ProjectSnapshotFile(srcB, "logs/dup.csv")
+            }
+        };
+
+        string dest = Path.Combine(_workDir, "dup.dragoverlay");
+        var result = new ProjectSaver().Save(dest, snapshot);
+
+        Assert.False(result.Ok);
+        Assert.Contains("dup", result.Message);
+        Assert.False(File.Exists(dest));
+    }
+
+    [Fact]
+    public void Save_RejectsUnsafeArchivePath()
+    {
+        string src = WriteFile("a.csv", SyntheticBytes("a"));
+
+        var snapshot = new ProjectSnapshot
+        {
+            Manifest = BaseManifest(new ProjectRunEntry
+            {
+                SourceType = ProjectSourceType.Castle,
+                UiSlot = 1,
+                PlotSlot = 1,
+                DisplayFileName = "a.csv",
+                SourcePath = "logs/castle-1.csv",
+                IsVisible = true
+            }),
+            Files = new[]
+            {
+                // Manifest entry above is fine; the file entry uses an unsafe path.
+                new ProjectSnapshotFile(src, "..\\evil.csv")
+            }
+        };
+
+        string dest = Path.Combine(_workDir, "unsafe.dragoverlay");
+        var result = new ProjectSaver().Save(dest, snapshot);
+
+        Assert.False(result.Ok);
+        Assert.False(File.Exists(dest));
+    }
+
+    [Fact]
+    public void Save_RejectsInvalidManifest()
+    {
+        string src = WriteFile("a.csv", SyntheticBytes("a"));
+
+        var bad = BaseManifest(new ProjectRunEntry
+        {
+            SourceType = ProjectSourceType.Castle,
+            UiSlot = 1,
+            PlotSlot = 1,
+            DisplayFileName = "a.csv",
+            SourcePath = "logs/castle-1.csv",
+            IsVisible = true
+        });
+        bad.AppBuild = ""; // validator requires AppBuild
+
+        var snapshot = new ProjectSnapshot
+        {
+            Manifest = bad,
+            Files = new[] { new ProjectSnapshotFile(src, "logs/castle-1.csv") }
+        };
+
+        string dest = Path.Combine(_workDir, "invalid.dragoverlay");
+        var result = new ProjectSaver().Save(dest, snapshot);
+
+        Assert.False(result.Ok);
+        Assert.False(File.Exists(dest));
+    }
+
+    // ---- Helpers --------------------------------------------------------
+
+    private string WriteFile(string name, byte[] bytes)
+    {
+        string path = Path.Combine(_workDir, name);
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    private static byte[] SyntheticBytes(string seed)
+    {
+        // Deterministic, but distinguishable per fixture, and long enough that
+        // accidental truncation is detectable.
+        var sb = new StringBuilder();
+        for (int i = 0; i < 32; i++)
+            sb.Append(seed).Append('-').Append(i).Append('\n');
+        return Encoding.UTF8.GetBytes(sb.ToString());
+    }
+
+    private static byte[] ReadEntryBytes(ZipArchiveEntry entry)
+    {
+        using var ms = new MemoryStream();
+        using (var s = entry.Open())
+            s.CopyTo(ms);
+        return ms.ToArray();
+    }
+
+    private static ProjectManifest BaseManifest(params ProjectRunEntry[] runs)
+    {
+        var manifest = new ProjectManifest
+        {
+            AppBuild = "1.13-test",
+            CreatedUtc = new DateTimeOffset(2026, 6, 20, 12, 0, 0, TimeSpan.Zero),
+            RunMode = ProjectRunMode.Drag,
+            ChannelVisibility = new Dictionary<string, bool>
+            {
+                ["RPM"] = true,
+                ["Throttle %"] = true,
+            }
+        };
+        foreach (var run in runs)
+            manifest.Runs.Add(run);
+        return manifest;
+    }
+}

--- a/src/CastleOverlayV2/MainFormPresenter.cs
+++ b/src/CastleOverlayV2/MainFormPresenter.cs
@@ -102,6 +102,7 @@ namespace CastleOverlayV2
                     return;
                 }
 
+                loaded.SourcePath = path;
                 _runs[slot] = loaded;
                 _selectedTuneSlot = slot;
                 Logger.Log($"Loaded Run {slot} - {Path.GetFileName(path)} - {loaded.DataPoints.Count} rows");
@@ -189,7 +190,8 @@ namespace CastleOverlayV2
                     IsRaceBox = true,
                     SplitTimes = rbData.SplitTimes,
                     SplitLabels = rbData.SplitLabels,
-                    FileName = Path.GetFileName(path)
+                    FileName = Path.GetFileName(path),
+                    SourcePath = path
                 };
                 run.Data["RaceBox Speed"] = points
                     .Select(p => new DataPoint { Time = p.Time.TotalSeconds, Y = p.SpeedMph })
@@ -392,6 +394,9 @@ namespace CastleOverlayV2
                 ShowResultMessage(result);
                 return;
             }
+
+            // Track the original .dat path so the project saver can embed the bytes.
+            result.Value!.SourcePath = path;
 
             if (slot.HasValue && run != null)
             {
@@ -664,6 +669,95 @@ namespace CastleOverlayV2
                 default:
                     return false;
             }
+        }
+
+        // ============================================================
+        // Project save (issue #86)
+        // ============================================================
+
+        /// <summary>
+        /// Snapshot the current analysis session into a <see cref="ProjectSnapshot"/>
+        /// suitable for handing to <see cref="ProjectSaver"/>.
+        /// Returns an error result if any loaded run is missing its on-disk source path
+        /// (which would prevent embedding the original bytes — required by issue #86).
+        /// </summary>
+        public LoadResult<ProjectSnapshot> BuildProjectSnapshot()
+        {
+            if (_runs.Count == 0)
+                return LoadResult<ProjectSnapshot>.Error("Save Project",
+                    "Load at least one Castle or RaceBox log before saving a project.");
+
+            var manifest = new ProjectManifest
+            {
+                AppBuild = _config.GetBuildNumber(),
+                CreatedUtc = DateTimeOffset.UtcNow,
+                RunMode = _isSpeedRunMode ? ProjectRunMode.Speed : ProjectRunMode.Drag,
+                ChannelVisibility = new Dictionary<string, bool>(
+                    _drawer.GetChannelStates(),
+                    StringComparer.OrdinalIgnoreCase)
+            };
+
+            var files = new List<ProjectSnapshotFile>();
+
+            foreach (var (plotSlot, run) in _runs.OrderBy(kv => kv.Key))
+            {
+                bool isRaceBox = plotSlot >= 4;
+                int uiSlot = isRaceBox ? plotSlot - 3 : plotSlot;
+                string sourceLabel = isRaceBox ? "racebox" : "castle";
+
+                if (string.IsNullOrWhiteSpace(run.SourcePath))
+                {
+                    return LoadResult<ProjectSnapshot>.Error("Save Project",
+                        $"Run {uiSlot} ({(isRaceBox ? "RaceBox" : "Castle")}) has no on-disk source path. " +
+                        "Re-load the file before saving the project.");
+                }
+
+                string sourceArchivePath = $"logs/{sourceLabel}-{uiSlot}{Path.GetExtension(run.SourcePath)?.ToLowerInvariant()}";
+                if (string.IsNullOrEmpty(Path.GetExtension(run.SourcePath)))
+                    sourceArchivePath = $"logs/{sourceLabel}-{uiSlot}.csv";
+
+                string? tuneArchivePath = null;
+                if (!isRaceBox && run.Tune?.SourcePath is { } tunePath && File.Exists(tunePath))
+                    tuneArchivePath = $"tunes/{sourceLabel}-{uiSlot}.dat";
+
+                manifest.Runs.Add(new ProjectRunEntry
+                {
+                    SourceType = isRaceBox ? ProjectSourceType.RaceBox : ProjectSourceType.Castle,
+                    UiSlot = uiSlot,
+                    PlotSlot = plotSlot,
+                    DisplayFileName = run.FileName ?? string.Empty,
+                    SourcePath = sourceArchivePath,
+                    IsVisible = _plot.GetRunVisibility(plotSlot),
+                    TimeShiftMs = run.TimeShiftMs,
+                    TunePath = tuneArchivePath,
+                    RadioSettings = run.Tune?.Radio
+                });
+
+                files.Add(new ProjectSnapshotFile(run.SourcePath, sourceArchivePath));
+                if (tuneArchivePath != null)
+                    files.Add(new ProjectSnapshotFile(run.Tune!.SourcePath!, tuneArchivePath));
+            }
+
+            return LoadResult<ProjectSnapshot>.Success(new ProjectSnapshot
+            {
+                Manifest = manifest,
+                Files = files
+            });
+        }
+
+        /// <summary>
+        /// Convenience: build the snapshot from current state and save to disk.
+        /// The caller is responsible for picking <paramref name="destinationPath"/> (e.g. via
+        /// <c>SaveFileDialog</c>) and showing any error returned here on the UI thread.
+        /// </summary>
+        public LoadResult<string> SaveProjectTo(string destinationPath)
+        {
+            var snapshot = BuildProjectSnapshot();
+            if (!snapshot.Ok)
+                return LoadResult<string>.Error(snapshot.Title ?? "Save Project",
+                    snapshot.Message ?? "Could not build the project snapshot.");
+
+            return new ProjectSaver().Save(destinationPath, snapshot.Value!);
         }
 
         // ============================================================

--- a/src/CastleOverlayV2/Models/ProjectSnapshot.cs
+++ b/src/CastleOverlayV2/Models/ProjectSnapshot.cs
@@ -1,0 +1,17 @@
+namespace CastleOverlayV2.Models
+{
+    /// <summary>
+    /// Input to the project saver: the manifest about to be written + the list of
+    /// source files that need to be embedded byte-for-byte. <see cref="ProjectSnapshotFile.SourcePath"/>
+    /// is a local-disk path; <see cref="ProjectSnapshotFile.ArchivePath"/> is the safe in-zip
+    /// path that already appears in the manifest (under <c>Runs[i].SourcePath</c> or
+    /// <c>Runs[i].TunePath</c>).
+    /// </summary>
+    public sealed class ProjectSnapshot
+    {
+        public ProjectManifest Manifest { get; init; } = new();
+        public IReadOnlyList<ProjectSnapshotFile> Files { get; init; } = Array.Empty<ProjectSnapshotFile>();
+    }
+
+    public sealed record ProjectSnapshotFile(string SourcePath, string ArchivePath);
+}

--- a/src/CastleOverlayV2/Models/RunData.cs
+++ b/src/CastleOverlayV2/Models/RunData.cs
@@ -5,6 +5,12 @@ namespace CastleOverlayV2.Models
     {
         public string FileName { get; set; }
 
+        // Absolute path of the original source file on disk. Tracked so the project saver
+        // can embed the original bytes back into a .dragoverlay package without
+        // reconstructing CSV content from parsed values. Null if loaded from somewhere
+        // other than a local file (rare).
+        public string? SourcePath { get; set; }
+
         // ✅ Castle logs use this (single combined point list)
         public List<DataPoint> DataPoints { get; set; }
 

--- a/src/CastleOverlayV2/Models/TuneSettings.cs
+++ b/src/CastleOverlayV2/Models/TuneSettings.cs
@@ -3,6 +3,13 @@ namespace CastleOverlayV2.Models
     public sealed class TuneSettings
     {
         public string SourceFileName { get; set; } = "";
+
+        /// <summary>
+        /// Absolute path of the original .dat file on disk. Tracked so the project saver
+        /// can embed the original bytes back into a .dragoverlay package. Null if the
+        /// tune was synthesised or otherwise has no on-disk origin.
+        /// </summary>
+        public string? SourcePath { get; set; }
         public string DeviceName { get; set; } = "";
         public string Firmware { get; set; } = "";
         public string CreatedText { get; set; } = "";

--- a/src/CastleOverlayV2/Services/ProjectSaver.cs
+++ b/src/CastleOverlayV2/Services/ProjectSaver.cs
@@ -1,0 +1,117 @@
+using CastleOverlayV2.Models;
+using System.IO.Compression;
+using System.Text;
+
+namespace CastleOverlayV2.Services
+{
+    /// <summary>
+    /// Writes a complete analysis session as a portable <c>.dragoverlay</c> ZIP package
+    /// (per <c>Docs/DragOverlay_UI_Spec.md</c> + issue #86).
+    ///
+    /// Atomicity: the ZIP is written to a temp file alongside the destination and only
+    /// renamed/replaced after every entry has been written and the archive closed.
+    /// Mid-write failure deletes the temp file and surfaces an error via
+    /// <see cref="LoadResult{T}"/> — the saver does not show UI dialogs itself
+    /// (the caller is responsible for that, per issue requirements).
+    /// </summary>
+    public sealed class ProjectSaver
+    {
+        private readonly ProjectManifestJson _manifestJson;
+
+        public ProjectSaver(ProjectManifestJson? manifestJson = null)
+        {
+            _manifestJson = manifestJson ?? new ProjectManifestJson();
+        }
+
+        public LoadResult<string> Save(string destinationPath, ProjectSnapshot snapshot)
+        {
+            if (string.IsNullOrWhiteSpace(destinationPath))
+                return LoadResult<string>.Error("Save Failed", "Destination path is required.");
+            if (snapshot is null)
+                return LoadResult<string>.Error("Save Failed", "Project snapshot is required.");
+
+            // Reject duplicate archive paths up front — the validator already rejects unsafe
+            // paths embedded in the manifest, but the file list is separate.
+            var seenArchivePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var file in snapshot.Files)
+            {
+                if (string.IsNullOrWhiteSpace(file.ArchivePath))
+                    return LoadResult<string>.Error("Save Failed", "Project file list contains an entry with no archive path.");
+                if (!ProjectManifestValidator.IsSafePackagePath(file.ArchivePath))
+                    return LoadResult<string>.Error("Save Failed", $"Archive path '{file.ArchivePath}' is not safe.");
+                if (!seenArchivePaths.Add(file.ArchivePath))
+                    return LoadResult<string>.Error("Save Failed", $"Archive path '{file.ArchivePath}' is duplicated in the project.");
+                if (string.IsNullOrWhiteSpace(file.SourcePath))
+                    return LoadResult<string>.Error("Save Failed", $"Missing source file for archive entry '{file.ArchivePath}'.");
+                if (!File.Exists(file.SourcePath))
+                    return LoadResult<string>.Error("Save Failed", $"Source file for '{file.ArchivePath}' no longer exists on disk:\n{file.SourcePath}");
+            }
+
+            string destinationDir = Path.GetDirectoryName(destinationPath) ?? "";
+            if (!string.IsNullOrEmpty(destinationDir))
+                Directory.CreateDirectory(destinationDir);
+
+            // Temp file in the same directory so File.Replace/Move stays atomic.
+            string tempPath = destinationPath + ".saving-" + Guid.NewGuid().ToString("N") + ".tmp";
+
+            try
+            {
+                string manifestJson;
+                try
+                {
+                    manifestJson = _manifestJson.Serialize(snapshot.Manifest);
+                }
+                catch (ProjectManifestException ex)
+                {
+                    return LoadResult<string>.Error("Save Failed", "Project manifest is invalid:\n" + ex.Message);
+                }
+
+                using (var zipStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
+                using (var archive = new ZipArchive(zipStream, ZipArchiveMode.Create, leaveOpen: false, entryNameEncoding: Encoding.UTF8))
+                {
+                    var manifestEntry = archive.CreateEntry(ProjectFormat.ManifestFileName, CompressionLevel.Optimal);
+                    using (var entryStream = manifestEntry.Open())
+                    using (var writer = new StreamWriter(entryStream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
+                    {
+                        writer.Write(manifestJson);
+                    }
+
+                    foreach (var file in snapshot.Files)
+                    {
+                        var entry = archive.CreateEntry(file.ArchivePath, CompressionLevel.Optimal);
+                        using var entryStream = entry.Open();
+                        using var source = File.OpenRead(file.SourcePath);
+                        source.CopyTo(entryStream);
+                    }
+                }
+
+                // Replace the existing file atomically, or rename the temp file into place.
+                if (File.Exists(destinationPath))
+                    File.Replace(tempPath, destinationPath, destinationBackupFileName: null);
+                else
+                    File.Move(tempPath, destinationPath);
+
+                return LoadResult<string>.Success(destinationPath);
+            }
+            catch (Exception ex)
+            {
+                TryDeleteTempFile(tempPath);
+                return LoadResult<string>.Error("Save Failed",
+                    "An error occurred while saving the project:\n" + ex.Message);
+            }
+        }
+
+        private static void TryDeleteTempFile(string tempPath)
+        {
+            try
+            {
+                if (File.Exists(tempPath))
+                    File.Delete(tempPath);
+            }
+            catch
+            {
+                // Best-effort cleanup; do not throw from the catch block.
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Closes #86 (project save/load phase 2.2). Adds the writer service + presenter snapshot builder so the current session can be saved as a portable `.dragoverlay` ZIP. The UI button is intentionally out of scope — that's #88.

## Diff
6 files, +613 / −1. Tests: 48/48 (was 40, +8 new).

## New: `Services/ProjectSaver.cs`
Receives a `ProjectSnapshot` and writes the ZIP atomically:

- Picks a unique temp file (`<dest>.saving-<guid>.tmp`) **inside** the destination directory so `File.Replace` / `File.Move` is atomic on Windows.
- Up-front validation: rejects duplicate archive paths, unsafe paths (caught by `ProjectManifestValidator.IsSafePackagePath`), and missing source files **before any I/O**.
- Serialises the manifest with the existing `ProjectManifestJson` (rejects invalid manifests with a clear error).
- Entries written via `ZipArchive` at `CompressionLevel.Optimal` with source bytes copied **verbatim** (never re-encoded from parsed models).
- On success: `File.Replace` an existing destination, or `File.Move` for a new one.
- On any failure: deletes the temp file and returns a `LoadResult` error. **The service does not call `MessageBox` directly.**

## New: `Models/ProjectSnapshot.cs`
Small wrapper: `ProjectSnapshot { ProjectManifest, IReadOnlyList<ProjectSnapshotFile> }` + `ProjectSnapshotFile(SourcePath, ArchivePath)`. `SourcePath` is a local-disk path; `ArchivePath` matches what's already declared in the manifest under `Runs[i].SourcePath` / `TunePath`.

## Models
- `RunData` gains `string? SourcePath` — full path of the original CSV on disk. Tracked by both load paths.
- `TuneSettings` gains `string? SourcePath` — same idea for the attached `.dat`.

## Presenter
- `LoadCastleRunAsync` / `LoadRaceBoxRunAsync` now stamp `run.SourcePath = path` on success.
- `AttachTuneToRun` stamps `result.Value.SourcePath = path`.
- New `BuildProjectSnapshot()` walks `_runs` in slot order and produces a snapshot:
  - Castle CSVs → `logs/castle-<uiSlot>.csv`
  - RaceBox CSVs → `logs/racebox-<uiSlot>.csv`
  - Attached tunes → `tunes/castle-<uiSlot>.dat`
  - Manifest captures: `AppBuild`, `CreatedUtc`, `RunMode`, `ChannelVisibility`, per-run `SourceType` / `UiSlot` / `PlotSlot` / `DisplayFileName` / `SourcePath` / `IsVisible` / `TimeShiftMs` / `TunePath` / `RadioSettings`.
- Returns an error if any loaded run is missing its on-disk source (told to re-load the file).
- New convenience `SaveProjectTo(string destinationPath)` wires `BuildProjectSnapshot` + `ProjectSaver` so the future #88 UI is one method call.

## Tests
8 new tests in `ProjectSaverTests.cs`:

| Test | Verifies |
|---|---|
| `Save_WritesPackage_For_CastleOnly_Session` | `project.json` present + Castle CSV bytes match |
| `Save_WritesPackage_For_RaceBoxOnly_Session` | RaceBox-only path |
| `Save_WritesPackage_For_Mixed_Session_WithTune` | Castle + RaceBox + tune, manifest round-trips with `TimeShiftMs` + `IsVisible` + `RadioSettings` |
| `Save_ReplacesExistingDestination` | Pre-existing destination file is overwritten cleanly |
| `Save_DoesNotLeavePartialFile_WhenSourceMissing` | Missing source → no destination, no `*.tmp` left behind |
| `Save_RejectsDuplicateArchivePaths` | Up-front rejection |
| `Save_RejectsUnsafeArchivePath` | Rejects `..\evil.csv` etc. |
| `Save_RejectsInvalidManifest` | Validator failures surface as Errors |

All tests use a temp working directory and clean up via `IDisposable`.

## Acceptance criteria (from #86)
- [x] Castle-only session saves successfully.
- [x] RaceBox-only session saves successfully.
- [x] Mixed Castle + RaceBox session saves successfully.
- [x] Attached tune files and manual radio settings are included per Castle run.
- [x] Alignment, run visibility, channel visibility, slot assignment, and Drag/Speed mode are recorded.
- [x] Original embedded files match the source bytes.
- [x] Save failure does not leave a corrupt final project.
- [x] Existing destination replacement is safe.
- [x] Unit tests inspect the produced ZIP and manifest.

## Out of scope
- Project-open / restoration — that's #87.
- Tune-panel Open/Save Project buttons — that's #88.

## Workflow
Per repo `CLAUDE.md`: yours to merge — I will not run `gh pr merge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)