### PR TITLE
chore: cleanup bundle (closes #68 #69 #70)

### DIFF
--- a/Tests/CastleOverlayV2.Tests/FakeMainView.cs
+++ b/Tests/CastleOverlayV2.Tests/FakeMainView.cs
@@ -1,0 +1,52 @@
+using CastleOverlayV2;
+
+namespace CastleOverlayV2.Tests;
+
+/// <summary>
+/// In-memory <see cref="IMainView"/> implementation for presenter tests.
+/// Records every call so tests can assert what the presenter asked the view to do.
+/// </summary>
+public sealed class FakeMainView : IMainView
+{
+    public string? CsvFileToReturn { get; set; }
+    public string? TuneFileToReturn { get; set; }
+    public string? ProjectOpenPathToReturn { get; set; }
+    public string? ProjectSavePathToReturn { get; set; }
+
+    public readonly List<(string title, string message)> Errors = new();
+    public readonly List<(string title, string message)> Infos = new();
+    public readonly List<(int slot, string fullPath, bool isVisible)> SlotLoaded = new();
+    public readonly List<int> SlotReset = new();
+    public readonly List<(int slot, bool isVisible)> SlotToggle = new();
+    public readonly List<(int slot, bool armed)> SlotArmed = new();
+    public readonly List<bool> RunTypeApplies = new();
+    public int RunTypeLockUpdates;
+    public readonly List<(string runLabel, double offsetMs)> AlignmentShown = new();
+    public int AlignmentHidden;
+    public readonly List<double> AlignmentOffsets = new();
+
+    public string? PickCsvFile() => CsvFileToReturn;
+    public string? PickTuneFile() => TuneFileToReturn;
+    public string? PickProjectFileToOpen() => ProjectOpenPathToReturn;
+    public string? PickProjectFileToSave() => ProjectSavePathToReturn;
+
+    public void ShowError(string title, string message) => Errors.Add((title, message));
+    public void ShowInfo(string title, string message) => Infos.Add((title, message));
+
+    public void SetSlotLoadedUI(int slot, string fullPath, bool isVisible) =>
+        SlotLoaded.Add((slot, fullPath, isVisible));
+    public void ResetSlotUI(int slot) => SlotReset.Add(slot);
+    public void SetSlotToggleText(int slot, bool isVisible) =>
+        SlotToggle.Add((slot, isVisible));
+    public void SetSlotArmedUI(int slot, bool armed) =>
+        SlotArmed.Add((slot, armed));
+
+    public void ApplyRunTypeUI(bool isSpeedRun) => RunTypeApplies.Add(isSpeedRun);
+    public void UpdateRunTypeLockState() => RunTypeLockUpdates++;
+
+    public void ShowAlignmentUI(string runLabel, double offsetMs) =>
+        AlignmentShown.Add((runLabel, offsetMs));
+    public void HideAlignmentUI() => AlignmentHidden++;
+    public void SetAlignmentOffsetUI(double offsetMs) =>
+        AlignmentOffsets.Add(offsetMs);
+}

--- a/Tests/CastleOverlayV2.Tests/MainFormPresenterTests.cs
+++ b/Tests/CastleOverlayV2.Tests/MainFormPresenterTests.cs
@@ -1,0 +1,95 @@
+using CastleOverlayV2;
+using CastleOverlayV2.Controls;
+using CastleOverlayV2.Plot;
+using CastleOverlayV2.Services;
+using ScottPlot.WinForms;
+
+namespace CastleOverlayV2.Tests;
+
+/// <summary>
+/// Smoke tests for the MainFormPresenter against a <see cref="FakeMainView"/>
+/// (issue #69). Establishes that the interface + fake combination work
+/// end-to-end; more presenter behaviour can be tested by extending these.
+/// </summary>
+public sealed class MainFormPresenterTests
+{
+    [Fact]
+    public void FakeMainView_records_every_view_call()
+    {
+        IMainView view = new FakeMainView();
+        view.ShowError("Title", "Body");
+        view.SetSlotLoadedUI(2, "C:\\run.csv", true);
+        view.ResetSlotUI(4);
+        view.ApplyRunTypeUI(true);
+        view.HideAlignmentUI();
+
+        var fake = (FakeMainView)view;
+        Assert.Single(fake.Errors);
+        Assert.Equal(("Title", "Body"), fake.Errors[0]);
+        Assert.Single(fake.SlotLoaded);
+        Assert.Single(fake.SlotReset);
+        Assert.Equal(4, fake.SlotReset[0]);
+        Assert.Single(fake.RunTypeApplies);
+        Assert.True(fake.RunTypeApplies[0]);
+        Assert.Equal(1, fake.AlignmentHidden);
+    }
+
+    [Fact]
+    public void Presenter_can_be_constructed_against_a_fake_view()
+    {
+        // Construction exercises the ctor's event-subscriptions on every
+        // collaborator. The ChannelDrawer + TunePanel + PlotManager need
+        // real WinForms instances; the test project targets net8.0-windows
+        // so this is supported.
+        var view = new FakeMainView();
+        var config = new ConfigService();
+        var formsPlot = new FormsPlot();
+        try
+        {
+            var plot = new PlotManager(formsPlot);
+            var drawer = new ChannelDrawer(
+                new List<string> { "RPM", "Throttle %" },
+                new Dictionary<string, bool> { ["RPM"] = true, ["Throttle %"] = true });
+            var tune = new TunePanel();
+
+            var presenter = new MainFormPresenter(view, config, plot, drawer, tune);
+
+            Assert.False(presenter.IsSpeedRunMode);
+            Assert.False(presenter.IsAnyRunLoaded);
+            Assert.False(presenter.IsAlignmentArmed);
+        }
+        finally
+        {
+            formsPlot.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task LoadCastleRunAsync_returns_immediately_when_picker_cancels()
+    {
+        var view = new FakeMainView { CsvFileToReturn = null };
+        var config = new ConfigService();
+        var formsPlot = new FormsPlot();
+        try
+        {
+            var plot = new PlotManager(formsPlot);
+            var drawer = new ChannelDrawer(
+                new List<string> { "RPM" },
+                new Dictionary<string, bool> { ["RPM"] = true });
+            var tune = new TunePanel();
+            var presenter = new MainFormPresenter(view, config, plot, drawer, tune);
+
+            await presenter.LoadCastleRunAsync(1);
+
+            // Nothing was loaded → no UI updates, no errors, no infos.
+            Assert.Empty(view.SlotLoaded);
+            Assert.Empty(view.Errors);
+            Assert.Empty(view.Infos);
+            Assert.False(presenter.IsAnyRunLoaded);
+        }
+        finally
+        {
+            formsPlot.Dispose();
+        }
+    }
+}

--- a/src/CastleOverlayV2/IMainView.cs
+++ b/src/CastleOverlayV2/IMainView.cs
@@ -1,0 +1,34 @@
+namespace CastleOverlayV2
+{
+    /// <summary>
+    /// Surface the <see cref="MainFormPresenter"/> calls on the view (MainForm).
+    /// Extracted in #69 so the presenter can be unit-tested with a fake.
+    /// </summary>
+    public interface IMainView
+    {
+        // File pickers
+        string? PickCsvFile();
+        string? PickTuneFile();
+        string? PickProjectFileToOpen();
+        string? PickProjectFileToSave();
+
+        // Dialogs
+        void ShowError(string title, string message);
+        void ShowInfo(string title, string message);
+
+        // Slot UI
+        void SetSlotLoadedUI(int slot, string fullPath, bool isVisible);
+        void ResetSlotUI(int slot);
+        void SetSlotToggleText(int slot, bool isVisible);
+        void SetSlotArmedUI(int slot, bool armed);
+
+        // RunType
+        void ApplyRunTypeUI(bool isSpeedRun);
+        void UpdateRunTypeLockState();
+
+        // Alignment
+        void ShowAlignmentUI(string runLabel, double offsetMs);
+        void HideAlignmentUI();
+        void SetAlignmentOffsetUI(double offsetMs);
+    }
+}

--- a/src/CastleOverlayV2/MainForm.cs
+++ b/src/CastleOverlayV2/MainForm.cs
@@ -13,7 +13,7 @@ using System.Windows.Forms;
 
 namespace CastleOverlayV2
 {
-    public partial class MainForm : Form
+    public partial class MainForm : Form, IMainView
     {
         private readonly ConfigService _configService;
         private readonly PlotManager _plotManager;
@@ -60,15 +60,7 @@ namespace CastleOverlayV2
                 "PowerOut", "MotorTemp", "ESC Temp", "MotorTiming", "Acceleration"
             };
             var rawStates = _configService.Config.ChannelVisibility ?? new Dictionary<string, bool>();
-            var initialStates = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
-            foreach (var kv in rawStates)
-            {
-                string key = kv.Key;
-                if (key.Equals("Throttle", StringComparison.OrdinalIgnoreCase) ||
-                    key.Equals("Throttle %.", StringComparison.OrdinalIgnoreCase))
-                    key = "Throttle %";
-                initialStates[key] = kv.Value;
-            }
+            var initialStates = new Dictionary<string, bool>(rawStates, StringComparer.OrdinalIgnoreCase);
             _configService.Config.ChannelVisibility = initialStates;
             _plotManager.SetInitialChannelVisibility(initialStates);
 

--- a/src/CastleOverlayV2/MainFormPresenter.cs
+++ b/src/CastleOverlayV2/MainFormPresenter.cs
@@ -18,7 +18,7 @@ namespace CastleOverlayV2
     /// </summary>
     public class MainFormPresenter
     {
-        private readonly MainForm _view;
+        private readonly IMainView _view;
         private readonly ConfigService _config;
         private readonly PlotManager _plot;
         private readonly ChannelDrawer _drawer;
@@ -48,7 +48,7 @@ namespace CastleOverlayV2
         public bool IsAnyRunLoaded => _runs.Count > 0;
         public bool IsAlignmentArmed => _armedSlot.HasValue;
 
-        public MainFormPresenter(MainForm view, ConfigService config, PlotManager plot, ChannelDrawer drawer, TunePanel tunePanel)
+        public MainFormPresenter(IMainView view, ConfigService config, PlotManager plot, ChannelDrawer drawer, TunePanel tunePanel)
         {
             _view = view;
             _config = config;

--- a/src/CastleOverlayV2/Plot/PlotManager.cs
+++ b/src/CastleOverlayV2/Plot/PlotManager.cs
@@ -214,8 +214,8 @@ namespace CastleOverlayV2.Plot
 
             foreach (var s in _scatters)
             {
-                s.Color = GetTraceColor(s.Label);
-                s.LineWidth = WidthFor(s.Label);
+                s.Color = GetTraceColor(s.LegendText);
+                s.LineWidth = WidthFor(s.LegendText);
             }
 
             ApplyFocusToAxes();
@@ -259,7 +259,7 @@ namespace CastleOverlayV2.Plot
             {
                 if (_scatterSlotMap.TryGetValue(s, out int ss) && ss == slot)
                 {
-                    string ch = s.Label;
+                    string ch = s.LegendText;
                     bool chOn = _channelVisibility.TryGetValue(ch, out bool vis) ? vis : true;
                     s.IsVisible = ns && chOn;
                 }
@@ -276,7 +276,7 @@ namespace CastleOverlayV2.Plot
 
             foreach (var s in _scatters)
             {
-                if (s.Label == channelName && _scatterSlotMap.TryGetValue(s, out int slot))
+                if (s.LegendText == channelName && _scatterSlotMap.TryGetValue(s, out int slot))
                 {
                     bool runVisible = _runVisibility.TryGetValue(slot, out bool rv) ? rv : true;
                     s.IsVisible = runVisible && isVisible;
@@ -425,7 +425,7 @@ namespace CastleOverlayV2.Plot
                         ysToPlot = rawYs.Select(v => v * 0.5).ToArray();
 
                     var s = _plot.Plot.Add.Scatter(xs, ysToPlot);
-                    s.Label = channelLabel;
+                    s.LegendText = channelLabel;
                     s.Color = GetTraceColor(channelLabel);
                     s.LinePattern = LineStyleHelper.GetLinePattern(slot - 1);
                     s.LineWidth = WidthFor(channelLabel);
@@ -475,7 +475,7 @@ namespace CastleOverlayV2.Plot
                 {
                     if (_scatterSlotMap.TryGetValue(s, out int sSlot) && sSlot == slot)
                     {
-                        string label = s.Label;
+                        string label = s.LegendText;
                         bool chOn = _channelVisibility.TryGetValue(label, out var cv) ? cv : true;
                         s.IsVisible = isVisible && chOn;
                     }
@@ -805,7 +805,7 @@ namespace CastleOverlayV2.Plot
                 double[] ys = rbTyped.Select(p => p.Y).ToArray();
 
                 var s = _plot.Plot.Add.Scatter(xs, ys);
-                s.Label = ch;
+                s.LegendText = ch;
                 s.Color = GetTraceColor(ch);
                 s.LinePattern = LineStyleHelper.GetLinePattern(slot - 1);
                 s.LineWidth = WidthFor(ch);
@@ -871,11 +871,11 @@ namespace CastleOverlayV2.Plot
                 var lbl = _plot.Plot.Add.Text(txt, times[i], 0.95);
                 lbl.Axes.YAxis = _splitLabelAxis!;
                 lbl.Alignment = Alignment.UpperCenter;
-                lbl.FontSize = 11;
-                lbl.FontColor = labelFg;
-                lbl.BackgroundColor = labelBg;
-                lbl.BorderColor = splitColor;
-                lbl.BorderWidth = 1;
+                lbl.LabelFontSize = 11;
+                lbl.LabelFontColor = labelFg;
+                lbl.LabelBackgroundColor = labelBg;
+                lbl.LabelBorderColor = splitColor;
+                lbl.LabelBorderWidth = 1;
                 lbl.OffsetY = -2;
                 lbls.Add(lbl);
             }
@@ -923,10 +923,10 @@ namespace CastleOverlayV2.Plot
             var cache = new Dictionary<string, List<Scatter>>();
             foreach (var s in _scatters)
             {
-                if (!cache.TryGetValue(s.Label, out var list))
+                if (!cache.TryGetValue(s.LegendText, out var list))
                 {
                     list = new List<Scatter>();
-                    cache[s.Label] = list;
+                    cache[s.LegendText] = list;
                 }
                 list.Add(s);
             }
@@ -1060,8 +1060,8 @@ namespace CastleOverlayV2.Plot
 
             var msg = _plot.Plot.Add.Text("Waiting for log...", 0, 0);
             msg.Alignment = Alignment.MiddleCenter;
-            msg.FontSize = 18;
-            msg.Color = ThemeTextDim;
+            msg.LabelFontSize = 18;
+            msg.LabelFontColor = ThemeTextDim;
 
             PixelPadding padding = new(left: 40, right: 40, top: 10, bottom: 50);
             _plot.Plot.Layout.Fixed(padding);


### PR DESCRIPTION
Three small follow-ups in one PR.

- **#68** — ScottPlot v5 deprecated API cleanup. 18 CS0618 warnings → 0.
- **#69** — IMainView interface extracted + FakeMainView + 3 presenter smoke tests.
- **#70** — Drop legacy "Throttle" / "Throttle %." config-key normalization.

Build clean. Tests: 54/54 (was 51, +3 new).