### PR TITLE
feat: settings dialog (default paths + voltage smoothing) + Castle-style palette

### DIFF
--- a/Tests/CastleOverlayV2.Tests/FakeMainView.cs
+++ b/Tests/CastleOverlayV2.Tests/FakeMainView.cs
@@ -26,7 +26,11 @@ public sealed class FakeMainView : IMainView
     public readonly List<double> AlignmentOffsets = new();
 
     public string? PickCsvFile() => CsvFileToReturn;
+    public string? PickCastleCsvFile() => CsvFileToReturn;
+    public string? PickRaceBoxCsvFile() => CsvFileToReturn;
     public string? PickTuneFile() => TuneFileToReturn;
+    public void ShowSettingsDialog() => SettingsShown++;
+    public int SettingsShown;
     public string? PickProjectFileToOpen() => ProjectOpenPathToReturn;
     public string? PickProjectFileToSave() => ProjectSavePathToReturn;
 

--- a/src/CastleOverlayV2/Controls/RunStrip.cs
+++ b/src/CastleOverlayV2/Controls/RunStrip.cs
@@ -31,6 +31,7 @@ namespace CastleOverlayV2.Controls
         public event Action<int>? ToggleRequested; // slot 1..6
         public event Action<int>? DeleteRequested; // slot 1..6
         public event Action<int>? ArmRequested;    // slot 1..6 (click on chip body)
+        public event Action? SettingsRequested;    // gear button
 
         // ---- State ----------------------------------------------------------
         private readonly SlotChip[] _chips = new SlotChip[7]; // index 1..6
@@ -46,6 +47,26 @@ namespace CastleOverlayV2.Controls
             Padding = new Padding(4, 4, 4, 4);
 
             _toolTip = new ToolTip { AutoPopDelay = 8000, InitialDelay = 400, ReshowDelay = 200, ShowAlways = true };
+
+            // Gear button docks Right so the chips shift over to make room.
+            var gear = new Button
+            {
+                Text = "⚙",
+                Dock = DockStyle.Right,
+                Width = 36,
+                FlatStyle = FlatStyle.Flat,
+                BackColor = SurfaceCard,
+                ForeColor = TextPrimary,
+                Margin = new Padding(0),
+                Padding = new Padding(0),
+                Font = new Font(SystemFonts.DefaultFont.FontFamily, 12f, FontStyle.Bold),
+                TabStop = false
+            };
+            gear.FlatAppearance.BorderColor = BorderDef;
+            gear.FlatAppearance.BorderSize = 1;
+            gear.Click += (_, _) => SettingsRequested?.Invoke();
+            _toolTip.SetToolTip(gear, "Settings");
+            Controls.Add(gear);
 
             _flow = new FlowLayoutPanel
             {

--- a/src/CastleOverlayV2/IMainView.cs
+++ b/src/CastleOverlayV2/IMainView.cs
@@ -8,6 +8,8 @@ namespace CastleOverlayV2
     {
         // File pickers
         string? PickCsvFile();
+        string? PickCastleCsvFile();
+        string? PickRaceBoxCsvFile();
         string? PickTuneFile();
         string? PickProjectFileToOpen();
         string? PickProjectFileToSave();
@@ -30,5 +32,8 @@ namespace CastleOverlayV2
         void ShowAlignmentUI(string runLabel, double offsetMs);
         void HideAlignmentUI();
         void SetAlignmentOffsetUI(double offsetMs);
+
+        // Settings
+        void ShowSettingsDialog();
     }
 }

--- a/src/CastleOverlayV2/MainForm.cs
+++ b/src/CastleOverlayV2/MainForm.cs
@@ -52,6 +52,9 @@ namespace CastleOverlayV2
             _plotManager = new PlotManager(formsPlot1);
             formsPlot1.Dock = DockStyle.Fill;
             _plotManager.SetupAllAxes();
+            _plotManager.SetVoltageSmoothing(
+                _configService.Config.VoltageSmoothingEnabled,
+                _configService.Config.VoltageSmoothingWindow);
 
             // Build canonical channel list + normalize saved visibility keys.
             var channelNames = new List<string>
@@ -97,6 +100,7 @@ namespace CastleOverlayV2
             _runStrip.ToggleRequested += slot => _presenter.ToggleRun(slot);
             _runStrip.DeleteRequested += slot => _presenter.DeleteRun(slot);
             _runStrip.ArmRequested += slot => _presenter.ToggleAlignmentArm(slot);
+            _runStrip.SettingsRequested += ShowSettingsDialog;
 
             _alignmentBar = new AlignmentBar();
             Controls.Add(_alignmentBar);
@@ -123,13 +127,26 @@ namespace CastleOverlayV2
         // Public view methods called by the Presenter
         // =====================================================================
 
-        /// <summary>Open file picker; null if cancelled.</summary>
-        public string? PickCsvFile()
+        public string? PickCsvFile() => PickCastleCsvFile();
+
+        public string? PickCastleCsvFile()
         {
             using var ofd = new OpenFileDialog
             {
-                Title = "Select CSV file",
-                Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*"
+                Title = "Select Castle CSV file",
+                Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
+                InitialDirectory = ExistingDirOrEmpty(_configService.Config.CastleLogDirectory)
+            };
+            return ofd.ShowDialog() == DialogResult.OK ? ofd.FileName : null;
+        }
+
+        public string? PickRaceBoxCsvFile()
+        {
+            using var ofd = new OpenFileDialog
+            {
+                Title = "Select RaceBox CSV file",
+                Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
+                InitialDirectory = ExistingDirOrEmpty(_configService.Config.RaceBoxLogDirectory)
             };
             return ofd.ShowDialog() == DialogResult.OK ? ofd.FileName : null;
         }
@@ -139,10 +156,14 @@ namespace CastleOverlayV2
             using var ofd = new OpenFileDialog
             {
                 Title = "Select Castle Link tune file",
-                Filter = "Castle tune files (*.dat)|*.dat|All files (*.*)|*.*"
+                Filter = "Castle tune files (*.dat)|*.dat|All files (*.*)|*.*",
+                InitialDirectory = ExistingDirOrEmpty(_configService.Config.TuneDirectory)
             };
             return ofd.ShowDialog() == DialogResult.OK ? ofd.FileName : null;
         }
+
+        private static string ExistingDirOrEmpty(string? path) =>
+            !string.IsNullOrWhiteSpace(path) && Directory.Exists(path) ? path : "";
 
         public string? PickProjectFileToOpen()
         {
@@ -165,6 +186,15 @@ namespace CastleOverlayV2
                 OverwritePrompt = true
             };
             return sfd.ShowDialog() == DialogResult.OK ? sfd.FileName : null;
+        }
+
+        public void ShowSettingsDialog()
+        {
+            using var dlg = new SettingsForm(_configService);
+            if (dlg.ShowDialog(this) == DialogResult.OK)
+                _plotManager?.SetVoltageSmoothing(
+                    _configService.Config.VoltageSmoothingEnabled,
+                    _configService.Config.VoltageSmoothingWindow);
         }
 
         public void ShowError(string title, string message) =>

--- a/src/CastleOverlayV2/MainFormPresenter.cs
+++ b/src/CastleOverlayV2/MainFormPresenter.cs
@@ -99,7 +99,7 @@ namespace CastleOverlayV2
         {
             Logger.Log($"LoadCastleRunAsync({slot}) started");
 
-            string? path = _view.PickCsvFile();
+            string? path = _view.PickCastleCsvFile();
             if (path == null) return;
 
             try
@@ -161,7 +161,7 @@ namespace CastleOverlayV2
             int plotSlot = uiSlot + 3;
             Logger.Log($"LoadRaceBoxRunAsync(UI {uiSlot} → plot slot {plotSlot}) started");
 
-            string? path = _view.PickCsvFile();
+            string? path = _view.PickRaceBoxCsvFile();
             if (path == null) return;
 
             try

--- a/src/CastleOverlayV2/Models/Config.cs
+++ b/src/CastleOverlayV2/Models/Config.cs
@@ -17,6 +17,15 @@ namespace CastleOverlayV2.Models
 
         public string BuildNumber { get; set; } = "1.13";
 
+        // ---- Default open folders (Settings dialog) -----------------------
+        public string CastleLogDirectory { get; set; } = "";
+        public string RaceBoxLogDirectory { get; set; } = "";
+        public string TuneDirectory { get; set; } = "";
+
+        // ---- Voltage smoothing (Settings dialog) --------------------------
+        public bool VoltageSmoothingEnabled { get; set; } = false;
+        public int VoltageSmoothingWindow { get; set; } = 5; // odd, 3..15
+
 
         public Config()
         {

--- a/src/CastleOverlayV2/Plot/PlotManager.cs
+++ b/src/CastleOverlayV2/Plot/PlotManager.cs
@@ -87,6 +87,44 @@ namespace CastleOverlayV2.Plot
 
         private bool _isFourPoleMode = false;
 
+        // Voltage smoothing (Settings dialog).
+        private bool _voltageSmoothingEnabled;
+        private int _voltageSmoothingWindow = 5;
+
+        /// <summary>
+        /// Configure voltage trace smoothing. When enabled, the plotted Voltage trace and
+        /// hover read-out use a centered moving-average filter with <paramref name="window"/>
+        /// samples (clamped odd, 3..15). Source data is never mutated.
+        /// </summary>
+        public void SetVoltageSmoothing(bool enabled, int window)
+        {
+            _voltageSmoothingEnabled = enabled;
+            if (window < 3) window = 3;
+            if (window > 15) window = 15;
+            if (window % 2 == 0) window += 1;
+            _voltageSmoothingWindow = window;
+
+            if (_runsBySlot.Count > 0)
+                PlotRuns(new Dictionary<int, RunData>(_runsBySlot));
+        }
+
+        private static double[] MovingAverage(double[] src, int window)
+        {
+            int n = src.Length;
+            if (n == 0 || window <= 1) return src;
+            int half = window / 2;
+            var dst = new double[n];
+            for (int i = 0; i < n; i++)
+            {
+                int lo = Math.Max(0, i - half);
+                int hi = Math.Min(n - 1, i + half);
+                double sum = 0;
+                for (int j = lo; j <= hi; j++) sum += src[j];
+                dst[i] = sum / (hi - lo + 1);
+            }
+            return dst;
+        }
+
         // ---- Scale Profiles (Drag vs Speed-Run) ----
         private enum ScaleProfile { Drag, SpeedRun }
         private ScaleProfile _activeProfile = ScaleProfile.Drag;
@@ -423,6 +461,8 @@ namespace CastleOverlayV2.Plot
                     double[] ysToPlot = rawYs;
                     if (_isFourPoleMode && channelLabel == "RPM")
                         ysToPlot = rawYs.Select(v => v * 0.5).ToArray();
+                    if (_voltageSmoothingEnabled && channelLabel == "Voltage")
+                        ysToPlot = MovingAverage(ysToPlot, _voltageSmoothingWindow);
 
                     var s = _plot.Plot.Add.Scatter(xs, ysToPlot);
                     s.LegendText = channelLabel;
@@ -451,7 +491,9 @@ namespace CastleOverlayV2.Plot
                     s.IsVisible = chOn && runOn;
 
                     _scatters.Add(s);
-                    _rawYMap[s] = rawYs;
+                    // Hover values follow the displayed array — when smoothing is on for
+                    // Voltage, the hover read-out reflects the smoothed curve too.
+                    _rawYMap[s] = ysToPlot;
                     _scatterSlotMap[s] = slot;
                 }
             }

--- a/src/CastleOverlayV2/SettingsForm.cs
+++ b/src/CastleOverlayV2/SettingsForm.cs
@@ -1,0 +1,208 @@
+using CastleOverlayV2.Models;
+using CastleOverlayV2.Services;
+
+namespace CastleOverlayV2
+{
+    /// <summary>
+    /// Modal settings dialog. Persists changes to <see cref="ConfigService"/> on OK.
+    /// </summary>
+    public sealed class SettingsForm : Form
+    {
+        private readonly ConfigService _configService;
+        private readonly TextBox _castleDir = new();
+        private readonly TextBox _raceboxDir = new();
+        private readonly TextBox _tuneDir = new();
+        private readonly CheckBox _smoothingEnabled = new();
+        private readonly NumericUpDown _smoothingWindow = new();
+
+        public SettingsForm(ConfigService configService)
+        {
+            _configService = configService;
+
+            Text = "Settings";
+            StartPosition = FormStartPosition.CenterParent;
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MinimizeBox = false;
+            MaximizeBox = false;
+            Width = 540;
+            Height = 360;
+            Font = new Font("Segoe UI", 9f);
+
+            BuildLayout();
+            LoadFromConfig();
+        }
+
+        private void BuildLayout()
+        {
+            var root = new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                ColumnCount = 1,
+                RowCount = 3,
+                Padding = new Padding(12),
+            };
+            root.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            root.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            root.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
+            Controls.Add(root);
+
+            // -------- Default folders -------------
+            root.Controls.Add(MakeSectionLabel("Default open folders"), 0, 0);
+            root.Controls.Add(BuildFolderPanel(), 0, 1);
+
+            // -------- Voltage smoothing -----------
+            var smoothingPanel = new FlowLayoutPanel
+            {
+                Dock = DockStyle.Top,
+                AutoSize = true,
+                FlowDirection = FlowDirection.LeftToRight,
+                Padding = new Padding(0, 12, 0, 0),
+            };
+            _smoothingEnabled.Text = "Smooth voltage trace";
+            _smoothingEnabled.AutoSize = true;
+            _smoothingEnabled.Margin = new Padding(0, 5, 12, 0);
+            _smoothingWindow.Minimum = 3;
+            _smoothingWindow.Maximum = 15;
+            _smoothingWindow.Increment = 2;
+            _smoothingWindow.Width = 60;
+            var winLabel = new Label
+            {
+                Text = "Window:",
+                AutoSize = true,
+                Margin = new Padding(8, 5, 4, 0),
+            };
+            smoothingPanel.Controls.Add(_smoothingEnabled);
+            smoothingPanel.Controls.Add(winLabel);
+            smoothingPanel.Controls.Add(_smoothingWindow);
+
+            var bottom = new Panel { Dock = DockStyle.Fill };
+            bottom.Controls.Add(smoothingPanel);
+            bottom.Controls.Add(MakeSectionLabel("Voltage smoothing"));
+            bottom.Controls.Add(BuildOkCancelRow());
+            root.Controls.Add(bottom, 0, 2);
+
+            // Lay out top-down inside `bottom`.
+            bottom.Controls[bottom.Controls.Count - 1].Dock = DockStyle.Bottom;
+        }
+
+        private Label MakeSectionLabel(string text) => new()
+        {
+            Text = text,
+            AutoSize = true,
+            Font = new Font(Font, FontStyle.Bold),
+            Margin = new Padding(0, 0, 0, 6),
+            Dock = DockStyle.Top,
+        };
+
+        private TableLayoutPanel BuildFolderPanel()
+        {
+            var panel = new TableLayoutPanel
+            {
+                ColumnCount = 3,
+                RowCount = 3,
+                Dock = DockStyle.Top,
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            };
+            panel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 130));
+            panel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100));
+            panel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 80));
+
+            AddFolderRow(panel, 0, "Castle log folder", _castleDir);
+            AddFolderRow(panel, 1, "RaceBox log folder", _raceboxDir);
+            AddFolderRow(panel, 2, "Tune folder", _tuneDir);
+            return panel;
+        }
+
+        private static void AddFolderRow(TableLayoutPanel panel, int row, string label, TextBox text)
+        {
+            panel.Controls.Add(new Label
+            {
+                Text = label,
+                AutoSize = false,
+                TextAlign = ContentAlignment.MiddleLeft,
+                Dock = DockStyle.Fill,
+                Margin = new Padding(0, 4, 8, 4),
+            }, 0, row);
+
+            text.Dock = DockStyle.Fill;
+            text.Margin = new Padding(0, 2, 8, 2);
+            panel.Controls.Add(text, 1, row);
+
+            var browse = new Button
+            {
+                Text = "Browse…",
+                Dock = DockStyle.Fill,
+                Margin = new Padding(0, 2, 0, 2),
+            };
+            browse.Click += (_, _) =>
+            {
+                using var dlg = new FolderBrowserDialog();
+                if (!string.IsNullOrWhiteSpace(text.Text) && Directory.Exists(text.Text))
+                    dlg.SelectedPath = text.Text;
+                if (dlg.ShowDialog() == DialogResult.OK)
+                    text.Text = dlg.SelectedPath;
+            };
+            panel.Controls.Add(browse, 2, row);
+        }
+
+        private Panel BuildOkCancelRow()
+        {
+            var row = new Panel
+            {
+                Height = 40,
+                Padding = new Padding(0, 8, 0, 0),
+            };
+            var ok = new Button
+            {
+                Text = "OK",
+                DialogResult = DialogResult.OK,
+                Width = 80,
+                Anchor = AnchorStyles.Right | AnchorStyles.Top,
+            };
+            ok.Location = new Point(row.Width - 180, 4);
+            var cancel = new Button
+            {
+                Text = "Cancel",
+                DialogResult = DialogResult.Cancel,
+                Width = 80,
+                Anchor = AnchorStyles.Right | AnchorStyles.Top,
+            };
+            cancel.Location = new Point(row.Width - 90, 4);
+            row.Controls.Add(ok);
+            row.Controls.Add(cancel);
+            AcceptButton = ok;
+            CancelButton = cancel;
+            ok.Click += (_, _) => SaveToConfig();
+            row.Resize += (_, _) =>
+            {
+                ok.Location = new Point(row.ClientSize.Width - 180, 4);
+                cancel.Location = new Point(row.ClientSize.Width - 90, 4);
+            };
+            return row;
+        }
+
+        private void LoadFromConfig()
+        {
+            var c = _configService.Config;
+            _castleDir.Text = c.CastleLogDirectory ?? "";
+            _raceboxDir.Text = c.RaceBoxLogDirectory ?? "";
+            _tuneDir.Text = c.TuneDirectory ?? "";
+            _smoothingEnabled.Checked = c.VoltageSmoothingEnabled;
+            _smoothingWindow.Value = Math.Max(3, Math.Min(15, c.VoltageSmoothingWindow | 1));
+        }
+
+        private void SaveToConfig()
+        {
+            var c = _configService.Config;
+            c.CastleLogDirectory = _castleDir.Text.Trim();
+            c.RaceBoxLogDirectory = _raceboxDir.Text.Trim();
+            c.TuneDirectory = _tuneDir.Text.Trim();
+            c.VoltageSmoothingEnabled = _smoothingEnabled.Checked;
+            int win = (int)_smoothingWindow.Value;
+            if (win % 2 == 0) win += 1; // force odd
+            c.VoltageSmoothingWindow = Math.Max(3, Math.Min(15, win));
+            _configService.Save();
+        }
+    }
+}

--- a/src/CastleOverlayV2/Utils/ColorMap.cs
+++ b/src/CastleOverlayV2/Utils/ColorMap.cs
@@ -1,31 +1,36 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace CastleOverlayV2.Utils
 {
     /// <summary>
-    /// Channel → trace color, dark-theme palette from <c>Docs/DragOverlay_UI_Spec.md</c> §5.
-    /// Channel hue is stable; focus state (handled in <see cref="Plot.PlotManager"/>) changes only opacity.
+    /// Channel → trace color. Restored to the Castle Link 2 reference palette to match
+    /// the v1.12 screenshot (Resources/main-ui-v1.12_1.png) — users compare traces against
+    /// Castle Link 2 side-by-side, so the hues need to match.
     /// </summary>
     public static class ChannelColorMap
     {
+        // Castle-style palette, brightened a touch for the dark plot background.
+        // Same hue family as Castle Link 2 — each channel reads as the "same color" —
+        // but lifted in luminance/saturation so traces actually pop. Throttle is
+        // white because black-on-black is invisible.
         private static readonly Dictionary<string, ScottPlot.Color> ChannelColors = new()
         {
             // Castle ESC channels
-            { "RPM", new ScottPlot.Color(0x4C, 0x9A, 0xED) },          // #4C9AED  blue
-            { "Throttle %", new ScottPlot.Color(0xEF, 0x9F, 0x27) },   // #EF9F27  amber
-            { "Current", new ScottPlot.Color(0x2B, 0xB4, 0x8A) },      // #2BB48A  teal
-            { "Voltage", new ScottPlot.Color(0xE0, 0x74, 0x4B) },      // #E0744B  coral
-            { "PowerOut", new ScottPlot.Color(0x7F, 0xB6, 0xF2) },     // #7FB6F2  light blue
-            { "Ripple", new ScottPlot.Color(0x97, 0xC4, 0x59) },       // #97C459  green
-            { "ESC Temp", new ScottPlot.Color(0xE2, 0x4B, 0x4A) },     // #E24B4A  red
-            { "MotorTemp", new ScottPlot.Color(0xBA, 0x75, 0x17) },    // #BA7517  deep amber
-            { "MotorTiming", new ScottPlot.Color(0xB4, 0xB2, 0xA9) },  // #B4B2A9  warm grey
-            { "Acceleration", new ScottPlot.Color(0xD8, 0x5A, 0x30) }, // #D85A30  dark coral
+            { "RPM", new ScottPlot.Color(0xCD, 0x57, 0x3F) },           // #CD573F  warm rust (was brown)
+            { "Throttle %", new ScottPlot.Color(0xF0, 0xF0, 0xF0) },    // #F0F0F0  white  (was black — invisible on dark)
+            { "Voltage", new ScottPlot.Color(0xFF, 0x4D, 0x4D) },       // #FF4D4D  punchy red
+            { "Current", new ScottPlot.Color(0x2E, 0xD9, 0x57) },       // #2ED957  bright green
+            { "Ripple", new ScottPlot.Color(0xC8, 0x55, 0xD6) },        // #C855D6  brighter purple
+            { "PowerOut", new ScottPlot.Color(0x6C, 0xB0, 0xE0) },      // #6CB0E0  brighter steel blue
+            { "MotorTemp", new ScottPlot.Color(0xB1, 0x8B, 0xF5) },     // #B18BF5  brighter medium purple
+            { "ESC Temp", new ScottPlot.Color(0xFF, 0x4A, 0xE0) },      // #FF4AE0  brighter magenta
+            { "MotorTiming", new ScottPlot.Color(0x4A, 0x7A, 0xFF) },   // #4A7AFF  lifted navy
+            { "Acceleration", new ScottPlot.Color(0x6F, 0xA1, 0xFF) },  // #6FA1FF  brighter royal blue
 
             // RaceBox GPS channels
-            { "RaceBox Speed", new ScottPlot.Color(0xD4, 0x53, 0x7E) },     // #D4537E  pink
-            { "RaceBox Distance", new ScottPlot.Color(0x63, 0x99, 0x22) },  // #639922  dark green
-            { "RaceBox G-Force X", new ScottPlot.Color(0x9F, 0x8F, 0xE0) }, // #9F8FE0  light purple
+            { "RaceBox Speed", new ScottPlot.Color(0xFF, 0xA0, 0x33) },     // #FFA033  brighter orange
+            { "RaceBox Distance", new ScottPlot.Color(0x8C, 0xCB, 0x35) },  // #8CCB35  brighter green
+            { "RaceBox G-Force X", new ScottPlot.Color(0x33, 0xE6, 0xE6) }, // #33E6E6  brighter turquoise
         };
 
         public static ScottPlot.Color GetColor(string channelName)
@@ -33,7 +38,6 @@ namespace CastleOverlayV2.Utils
             if (ChannelColors.TryGetValue(channelName, out var color))
                 return color;
 
-            // Fallback for any unmapped channel: text.secondary grey.
             return new ScottPlot.Color(0x9A, 0xA3, 0xB2);
         }
     }


### PR DESCRIPTION
## What's in

- **Settings dialog** opened from a new gear button on the run strip:
  - Default open folders for Castle log / RaceBox log / Tune
  - Voltage smoothing toggle + window size (centered moving average, 3–15 samples, odd)
- **Castle-style palette** restored from the v1.12 screenshot, then brightened so traces pop on the dark plot. Throttle is now white (black was invisible).
- **Pickers respect saved paths** — `PickCastleCsvFile` / `PickRaceBoxCsvFile` / `PickTuneFile` each set `InitialDirectory` from the corresponding setting.
- **Voltage smoothing applies at plot-time only** — source `DataPoint.Voltage` is never mutated. Hover values follow the smoothed curve.

Build: 0 errors. Tests: 54/54.