### PR TITLE
chore: dark theme cleanup for toolbar + settings dialog

### DIFF
--- a/src/CastleOverlayV2/Controls/RunStrip.cs
+++ b/src/CastleOverlayV2/Controls/RunStrip.cs
@@ -60,10 +60,13 @@ namespace CastleOverlayV2.Controls
                 Margin = new Padding(0),
                 Padding = new Padding(0),
                 Font = new Font(SystemFonts.DefaultFont.FontFamily, 12f, FontStyle.Bold),
-                TabStop = false
+                TabStop = false,
+                UseVisualStyleBackColor = false
             };
             gear.FlatAppearance.BorderColor = BorderDef;
             gear.FlatAppearance.BorderSize = 1;
+            gear.FlatAppearance.MouseOverBackColor = SurfaceBar;
+            gear.FlatAppearance.MouseDownBackColor = SurfaceBar;
             gear.Click += (_, _) => SettingsRequested?.Invoke();
             _toolTip.SetToolTip(gear, "Settings");
             Controls.Add(gear);
@@ -153,10 +156,13 @@ namespace CastleOverlayV2.Controls
                     BackColor = SurfaceCardDim,
                     ForeColor = TextSecond,
                     Font = new Font(SystemFonts.DefaultFont.FontFamily, 8.5f),
-                    TabStop = false
+                    TabStop = false,
+                    UseVisualStyleBackColor = false   // honour BackColor on Win11 dark systems
                 };
                 _loadBtn.FlatAppearance.BorderColor = BorderDef;
                 _loadBtn.FlatAppearance.BorderSize = 1;
+                _loadBtn.FlatAppearance.MouseOverBackColor = SurfaceCard;
+                _loadBtn.FlatAppearance.MouseDownBackColor = SurfaceCard;
                 _loadBtn.Click += (_, _) => LoadClicked?.Invoke();
                 Controls.Add(_loadBtn);
 
@@ -191,9 +197,12 @@ namespace CastleOverlayV2.Controls
                     Margin = new Padding(0),
                     Padding = new Padding(0),
                     Font = new Font(SystemFonts.DefaultFont.FontFamily, 10f),
-                    TabStop = false
+                    TabStop = false,
+                    UseVisualStyleBackColor = false
                 };
                 _eyeBtn.FlatAppearance.BorderSize = 0;
+                _eyeBtn.FlatAppearance.MouseOverBackColor = SurfaceCardDim;
+                _eyeBtn.FlatAppearance.MouseDownBackColor = SurfaceCardDim;
                 _eyeBtn.Click += (_, _) => ToggleClicked?.Invoke();
                 layout.Controls.Add(_eyeBtn, 0, 0);
 
@@ -232,9 +241,12 @@ namespace CastleOverlayV2.Controls
                     Margin = new Padding(0),
                     Padding = new Padding(0),
                     Font = new Font(SystemFonts.DefaultFont.FontFamily, 12f, FontStyle.Bold),
-                    TabStop = false
+                    TabStop = false,
+                    UseVisualStyleBackColor = false
                 };
                 _deleteBtn.FlatAppearance.BorderSize = 0;
+                _deleteBtn.FlatAppearance.MouseOverBackColor = SurfaceCardDim;
+                _deleteBtn.FlatAppearance.MouseDownBackColor = SurfaceCardDim;
                 _deleteBtn.Click += (_, _) => DeleteClicked?.Invoke();
                 layout.Controls.Add(_deleteBtn, 3, 0);
 

--- a/src/CastleOverlayV2/MainForm.cs
+++ b/src/CastleOverlayV2/MainForm.cs
@@ -28,6 +28,7 @@ namespace CastleOverlayV2
             _configService = configService ?? new ConfigService();
 
             InitializeComponent();
+            HandleCreated += (_, _) => Utils.WindowsDarkTitleBar.Apply(Handle);
 
             // Dark theme — surface.window (chrome around the plot).
             // Phase 1 minimum: form + plot are dark; the run strip / drawer get full
@@ -89,6 +90,13 @@ namespace CastleOverlayV2
             // hidden via topButtonPanel.Visible = false; the runTypeSwitch (Drag/Speed
             // pill) lives in headerRow's column 1 and stays visible.
             topButtonPanel.Visible = false;
+            // Dark-theme every container the Designer leaves at default light gray, so
+            // there are no white strips behind the run strip, plot, or pill.
+            var surfaceBar    = Color.FromArgb(0x1B, 0x21, 0x2B);
+            var surfaceWindow = Color.FromArgb(0x13, 0x17, 0x1E);
+            mainContainer.BackColor = surfaceWindow;
+            headerRow.BackColor = surfaceBar;
+            topButtonPanel.BackColor = surfaceBar;
 
             _runStrip = new RunStrip();
             Controls.Add(_runStrip); // Dock = Top
@@ -312,28 +320,34 @@ namespace CastleOverlayV2
         //   (Touches Designer-named controls — stays in the view.)
         // =====================================================================
 
-        // RunType colors
-        private readonly Color _rtBaseBg = Color.FromArgb(235, 235, 235);
+        // RunType colors (dark theme — match the rest of the app).
+        private readonly Color _rtBaseBg = Color.FromArgb(0x1A, 0x1F, 0x27);   // surface.card
+        private readonly Color _rtKnobBg = Color.FromArgb(0x17, 0x22, 0x30);   // surface.card.focus
 
         private void SyncRunTypeUI(bool isSpeedRun, bool locked)
         {
             if (runTypeKnob != null)
+            {
                 runTypeKnob.Left = isSpeedRun ? 54 : 0;
+                runTypeKnob.BackColor = _rtKnobBg;
+            }
 
             if (runTypeSwitch != null)
                 runTypeSwitch.BackColor = _rtBaseBg;
 
-            var activeFg = Color.FromArgb(35, 35, 35);
-            var inactiveFg = Color.FromArgb(140, 140, 140);
+            var activeFg = Color.FromArgb(0xE6, 0xE9, 0xEF);    // text.primary
+            var inactiveFg = Color.FromArgb(0x5C, 0x65, 0x73);  // text.dim
 
             if (runTypeDrag != null)
             {
                 runTypeDrag.ForeColor = isSpeedRun ? inactiveFg : activeFg;
+                runTypeDrag.BackColor = _rtBaseBg;
                 runTypeDrag.Font = new Font(runTypeDrag.Font, isSpeedRun ? FontStyle.Regular : FontStyle.Bold);
             }
             if (runTypeSpeed != null)
             {
                 runTypeSpeed.ForeColor = isSpeedRun ? activeFg : inactiveFg;
+                runTypeSpeed.BackColor = _rtBaseBg;
                 runTypeSpeed.Font = new Font(runTypeSpeed.Font, isSpeedRun ? FontStyle.Bold : FontStyle.Regular);
             }
 

--- a/src/CastleOverlayV2/SettingsForm.cs
+++ b/src/CastleOverlayV2/SettingsForm.cs
@@ -8,6 +8,14 @@ namespace CastleOverlayV2
     /// </summary>
     public sealed class SettingsForm : Form
     {
+        // Dark theme tokens (matches the rest of the app).
+        private static readonly Color SurfaceWindow = Color.FromArgb(0x13, 0x17, 0x1E);
+        private static readonly Color SurfaceCard   = Color.FromArgb(0x1A, 0x1F, 0x27);
+        private static readonly Color SurfaceInput  = Color.FromArgb(0x20, 0x26, 0x31);
+        private static readonly Color TextPrimary   = Color.FromArgb(0xE6, 0xE9, 0xEF);
+        private static readonly Color TextSecond    = Color.FromArgb(0x9A, 0xA3, 0xB2);
+        private static readonly Color BorderDef     = Color.FromArgb(0x29, 0x2F, 0x39);
+
         private readonly ConfigService _configService;
         private readonly TextBox _castleDir = new();
         private readonly TextBox _raceboxDir = new();
@@ -27,6 +35,10 @@ namespace CastleOverlayV2
             Width = 540;
             Height = 360;
             Font = new Font("Segoe UI", 9f);
+            BackColor = SurfaceWindow;
+            ForeColor = TextPrimary;
+
+            HandleCreated += (_, _) => Utils.WindowsDarkTitleBar.Apply(Handle);
 
             BuildLayout();
             LoadFromConfig();
@@ -61,15 +73,21 @@ namespace CastleOverlayV2
             _smoothingEnabled.Text = "Smooth voltage trace";
             _smoothingEnabled.AutoSize = true;
             _smoothingEnabled.Margin = new Padding(0, 5, 12, 0);
+            _smoothingEnabled.ForeColor = TextPrimary;
+            _smoothingEnabled.BackColor = SurfaceWindow;
             _smoothingWindow.Minimum = 3;
             _smoothingWindow.Maximum = 15;
             _smoothingWindow.Increment = 2;
             _smoothingWindow.Width = 60;
+            _smoothingWindow.BackColor = SurfaceInput;
+            _smoothingWindow.ForeColor = TextPrimary;
+            _smoothingWindow.BorderStyle = BorderStyle.FixedSingle;
             var winLabel = new Label
             {
                 Text = "Window:",
                 AutoSize = true,
                 Margin = new Padding(8, 5, 4, 0),
+                ForeColor = TextSecond,
             };
             smoothingPanel.Controls.Add(_smoothingEnabled);
             smoothingPanel.Controls.Add(winLabel);
@@ -90,6 +108,7 @@ namespace CastleOverlayV2
             Text = text,
             AutoSize = true,
             Font = new Font(Font, FontStyle.Bold),
+            ForeColor = TextSecond,
             Margin = new Padding(0, 0, 0, 6),
             Dock = DockStyle.Top,
         };
@@ -123,18 +142,19 @@ namespace CastleOverlayV2
                 TextAlign = ContentAlignment.MiddleLeft,
                 Dock = DockStyle.Fill,
                 Margin = new Padding(0, 4, 8, 4),
+                ForeColor = TextSecond,
             }, 0, row);
 
             text.Dock = DockStyle.Fill;
             text.Margin = new Padding(0, 2, 8, 2);
+            text.BackColor = SurfaceInput;
+            text.ForeColor = TextPrimary;
+            text.BorderStyle = BorderStyle.FixedSingle;
             panel.Controls.Add(text, 1, row);
 
-            var browse = new Button
-            {
-                Text = "Browse…",
-                Dock = DockStyle.Fill,
-                Margin = new Padding(0, 2, 0, 2),
-            };
+            var browse = MakeDarkButton("Browse…");
+            browse.Dock = DockStyle.Fill;
+            browse.Margin = new Padding(0, 2, 0, 2);
             browse.Click += (_, _) =>
             {
                 using var dlg = new FolderBrowserDialog();
@@ -146,6 +166,24 @@ namespace CastleOverlayV2
             panel.Controls.Add(browse, 2, row);
         }
 
+        private static Button MakeDarkButton(string text)
+        {
+            var b = new Button
+            {
+                Text = text,
+                FlatStyle = FlatStyle.Flat,
+                BackColor = SurfaceCard,
+                ForeColor = TextPrimary,
+                Font = new Font("Segoe UI", 9f),
+                UseVisualStyleBackColor = false,
+            };
+            b.FlatAppearance.BorderColor = BorderDef;
+            b.FlatAppearance.BorderSize = 1;
+            b.FlatAppearance.MouseOverBackColor = SurfaceInput;
+            b.FlatAppearance.MouseDownBackColor = SurfaceInput;
+            return b;
+        }
+
         private Panel BuildOkCancelRow()
         {
             var row = new Panel
@@ -153,21 +191,15 @@ namespace CastleOverlayV2
                 Height = 40,
                 Padding = new Padding(0, 8, 0, 0),
             };
-            var ok = new Button
-            {
-                Text = "OK",
-                DialogResult = DialogResult.OK,
-                Width = 80,
-                Anchor = AnchorStyles.Right | AnchorStyles.Top,
-            };
+            var ok = MakeDarkButton("OK");
+            ok.DialogResult = DialogResult.OK;
+            ok.Width = 80;
+            ok.Anchor = AnchorStyles.Right | AnchorStyles.Top;
             ok.Location = new Point(row.Width - 180, 4);
-            var cancel = new Button
-            {
-                Text = "Cancel",
-                DialogResult = DialogResult.Cancel,
-                Width = 80,
-                Anchor = AnchorStyles.Right | AnchorStyles.Top,
-            };
+            var cancel = MakeDarkButton("Cancel");
+            cancel.DialogResult = DialogResult.Cancel;
+            cancel.Width = 80;
+            cancel.Anchor = AnchorStyles.Right | AnchorStyles.Top;
             cancel.Location = new Point(row.Width - 90, 4);
             row.Controls.Add(ok);
             row.Controls.Add(cancel);

--- a/src/CastleOverlayV2/Utils/WindowsDarkTitleBar.cs
+++ b/src/CastleOverlayV2/Utils/WindowsDarkTitleBar.cs
@@ -1,0 +1,27 @@
+using System.Runtime.InteropServices;
+
+namespace CastleOverlayV2.Utils
+{
+    /// <summary>
+    /// Force the Windows 10/11 native title bar to render dark for a given window.
+    /// Works on Windows 10 1809+ and Windows 11. Silently no-ops on older systems.
+    /// </summary>
+    public static class WindowsDarkTitleBar
+    {
+        // DWMWA_USE_IMMERSIVE_DARK_MODE attribute id — 20 on current builds, 19 on 1809–1903.
+        private const int DwmwaUseImmersiveDarkMode = 20;
+        private const int DwmwaUseImmersiveDarkModeBefore20H1 = 19;
+
+        [DllImport("dwmapi.dll")]
+        private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attribute, ref int value, int size);
+
+        public static void Apply(IntPtr hwnd)
+        {
+            if (hwnd == IntPtr.Zero) return;
+            int useDark = 1;
+            // Try the modern attribute first; if it fails, try the pre-20H1 one. Errors swallowed.
+            if (DwmSetWindowAttribute(hwnd, DwmwaUseImmersiveDarkMode, ref useDark, sizeof(int)) != 0)
+                _ = DwmSetWindowAttribute(hwnd, DwmwaUseImmersiveDarkModeBefore20H1, ref useDark, sizeof(int));
+        }
+    }
+}


### PR DESCRIPTION
- Toolbar / header / Drag-Speed pill all dark-themed (no more light strips behind the chips).
- Chip + gear + Settings buttons use `UseVisualStyleBackColor = false` so Win11 honours the dark BackColor.
- SettingsForm dark themed end-to-end.
- New P/Invoke (`DwmSetWindowAttribute(DWMWA_USE_IMMERSIVE_DARK_MODE)`) applied to MainForm + SettingsForm so the native Windows title bars render dark on Win10 1809+ / Win11.

Tests: 54/54.