### PR TITLE
ci: tag-driven release workflow + installer parameterization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release
+
+# Push a tag like v1.14 to build the installer and publish a GitHub Release with it attached.
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version (e.g. 1.14) — used when running manually'
+        required: true
+        default: '1.14'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Resolve version
+        id: ver
+        shell: pwsh
+        run: |
+          if ($env:GITHUB_REF -like 'refs/tags/v*') {
+            $ver = $env:GITHUB_REF.Substring('refs/tags/v'.Length)
+          } else {
+            $ver = '${{ github.event.inputs.version }}'
+          }
+          echo "version=$ver" >> $env:GITHUB_OUTPUT
+          Write-Host "Building DragOverlay v$ver"
+
+      - name: Restore + build + test
+        run: |
+          dotnet restore src/CastleOverlayV2/CastleOverlayV2.sln
+          dotnet build src/CastleOverlayV2/CastleOverlayV2.csproj -c Release --no-restore
+          dotnet test Tests/CastleOverlayV2.Tests/CastleOverlayV2.Tests.csproj -c Release --no-build --nologo
+
+      - name: Publish app
+        run: >
+          dotnet publish src/CastleOverlayV2/CastleOverlayV2.csproj
+          -c Release
+          -r win-x64
+          --self-contained false
+          -o publish
+
+      - name: Install Inno Setup
+        run: choco install innosetup --no-progress -y
+
+      - name: Compile installer
+        shell: pwsh
+        run: |
+          $version = '${{ steps.ver.outputs.version }}'
+          $publishDir = (Resolve-Path 'publish').Path
+          $outputDir = Join-Path $PWD 'installer-out'
+          New-Item -ItemType Directory -Force -Path $outputDir | Out-Null
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" `
+            "/DMyAppVersion=$version" `
+            "/DMyPublishDir=$publishDir" `
+            "/DMyOutputDir=$outputDir" `
+            installer/installer.iss
+          if ($LASTEXITCODE -ne 0) { throw "ISCC failed with $LASTEXITCODE" }
+          Get-ChildItem $outputDir
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: DragOverlay v${{ steps.ver.outputs.version }}
+          files: installer-out/DragOverlay-Setup-v${{ steps.ver.outputs.version }}.exe
+          generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/installer/installer.iss
+++ b/installer/installer.iss
@@ -1,14 +1,25 @@
 ; -----------------------------------------------
-; DragOverlay Inno Setup Script (Build 1.13)
+; DragOverlay Inno Setup Script
+;
+; Defaults below are Stewart's local-build paths. CI (.github/workflows/release.yml)
+; overrides MyPublishDir / MyOutputDir / MyAppVersion via /D arguments to ISCC.
 ; -----------------------------------------------
 
 #define MyAppName     "DragOverlay"
 #define MyCompany     "Stew-Mac"
 #define MyAppExeName  "CastleOverlayV2.exe"
-#define MyAppVersion  "1.13"
 
-#define MyPublishDir  "C:\Users\Stewart McMillan\DragOverlay\Publish"
-#define MyOutputDir   "C:\Users\Stewart McMillan\DragOverlay\Publish\InstallerOutput"
+#ifndef MyAppVersion
+  #define MyAppVersion "1.13"
+#endif
+
+#ifndef MyPublishDir
+  #define MyPublishDir "C:\Users\Stewart McMillan\DragOverlay\Publish"
+#endif
+
+#ifndef MyOutputDir
+  #define MyOutputDir "C:\Users\Stewart McMillan\DragOverlay\Publish\InstallerOutput"
+#endif
 
 #define MyAppId "{{7C2F6B4A-8C0E-4C5C-9E7B-2D6B3B2D2F31}}"
 


### PR DESCRIPTION
Push a tag like `v1.14` (or use Actions → Release → Run workflow) and the runner:
- Builds + tests
- Publishes the app
- Installs Inno Setup, compiles `installer/installer.iss` with `/D` overrides
- Creates a GitHub Release named "DragOverlay v<version>" with `DragOverlay-Setup-v<version>.exe` attached

`installer.iss` wraps the three local-path defines in `#ifndef` so Stewart's local build still works unchanged.