### PR TITLE
Prepare v1.15 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Release
 
-# Push a tag like v1.14 to build the installer and publish a GitHub Release with it attached.
+# Push a tag like v1.15 to build the installer and publish a GitHub Release with it attached.
 on:
   push:
     tags:
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version (e.g. 1.14) — used when running manually'
+        description: 'Version (e.g. 1.15) — used when running manually'
         required: true
-        default: '1.14'
+        default: '1.15'
 
 permissions:
   contents: write
@@ -42,7 +42,7 @@ jobs:
       - name: Restore + build + test
         run: |
           dotnet restore src/CastleOverlayV2/CastleOverlayV2.sln
-          dotnet build src/CastleOverlayV2/CastleOverlayV2.csproj -c Release --no-restore
+          dotnet build src/CastleOverlayV2/CastleOverlayV2.sln -c Release --no-restore
           dotnet test Tests/CastleOverlayV2.Tests/CastleOverlayV2.Tests.csproj -c Release --no-build --nologo
 
       - name: Publish app

--- a/installer/installer.iss
+++ b/installer/installer.iss
@@ -10,7 +10,7 @@
 #define MyAppExeName  "CastleOverlayV2.exe"
 
 #ifndef MyAppVersion
-  #define MyAppVersion "1.13"
+  #define MyAppVersion "1.15"
 #endif
 
 #ifndef MyPublishDir

--- a/src/CastleOverlayV2/Models/Config.cs
+++ b/src/CastleOverlayV2/Models/Config.cs
@@ -15,7 +15,7 @@ namespace CastleOverlayV2.Models
 
         public bool EnableDebugLogging { get; set; } = false;
 
-        public string BuildNumber { get; set; } = "1.13";
+        public string BuildNumber { get; set; } = "1.15";
 
         // ---- Default open folders (Settings dialog) -----------------------
         public string CastleLogDirectory { get; set; } = "";


### PR DESCRIPTION
## Summary
- Bump app build/version defaults to 1.15.
- Update release workflow defaults/examples for v1.15.
- Fix the release workflow to build the solution before running tests with `--no-build`, so the test DLL exists in CI.

## Verification
- `dotnet restore src/CastleOverlayV2/CastleOverlayV2.sln`
- `dotnet build src/CastleOverlayV2/CastleOverlayV2.sln -c Release --no-restore`
- `dotnet test Tests/CastleOverlayV2.Tests/CastleOverlayV2.Tests.csproj -c Release --no-build --nologo`
- Result: 54 passed, 0 failed.