### PR TITLE
Manual log trimming via right-click on the plot

### DIFF
--- a/src/CastleOverlayV2/MainFormPresenter.cs
+++ b/src/CastleOverlayV2/MainFormPresenter.cs
@@ -65,6 +65,9 @@ namespace CastleOverlayV2
             _drawer.ChannelFocused += OnChannelFocused;
             _plot.CursorMoved += OnCursorMoved;
             _plot.AlignmentDragged += OnAlignmentDragged;
+            _plot.TrimBeforeRequested += plotX => TrimArmedRun(plotX, before: true);
+            _plot.TrimAfterRequested += plotX => TrimArmedRun(plotX, before: false);
+            _plot.TrimResetRequested += ResetArmedRunTrim;
             _tunePanel.AttachTuneRequested += AttachTuneToRun;
             _tunePanel.RadioSettingsChanged += UpdateRadioSettings;
             _tunePanel.SelectedRunChanged += SelectTuneRun;
@@ -348,6 +351,8 @@ namespace CastleOverlayV2
             _view.SetSlotArmedUI(slot, true);
             _view.ShowAlignmentUI(run.FileName, run.TimeShiftMs);
             _plot.SetAlignmentMode(true);
+            // Manual trim is Castle-only (RaceBox uses a different data shape and isn't auto-trimmed).
+            _plot.SetManualTrimAvailable(!run.IsRaceBox);
         }
 
         public void DisarmAlignment()
@@ -358,6 +363,7 @@ namespace CastleOverlayV2
             _armedSlot = null;
             _view.HideAlignmentUI();
             _plot.SetAlignmentMode(false);
+            _plot.SetManualTrimAvailable(false);
         }
 
         public void NudgeArmedRun(int direction, bool coarse)
@@ -394,6 +400,53 @@ namespace CastleOverlayV2
                 $"Auto-align slot {_armedSlot.Value}: offset={run.TimeShiftMs:F1}ms");
             PlotAllRuns();
             UpdateAlignmentOffset();
+        }
+
+        /// <summary>
+        /// Manually trim the armed Castle run, removing samples before (or after) the
+        /// right-clicked time. Reversible — operates over the run's baseline and can be
+        /// undone with <see cref="ResetArmedRunTrim"/>.
+        /// </summary>
+        private void TrimArmedRun(double plotX, bool before)
+        {
+            if (!_armedSlot.HasValue || !_runs.TryGetValue(_armedSlot.Value, out var run))
+                return;
+            if (run.IsRaceBox)
+            {
+                _view.ShowInfo("Trim", "Manual trim is only available for Castle log runs.");
+                return;
+            }
+
+            run.CaptureTrimBaseline();
+
+            // Plot X is in display seconds; convert to the run's own (re-zeroed) time.
+            // The global Castle time shift is currently always 0, so only the per-run
+            // alignment offset needs removing.
+            double runTime = plotX - run.TimeShiftMs / 1000.0;
+
+            if (before)
+                run.TrimStartTime = runTime;
+            else
+                run.TrimEndTime = runTime;
+
+            run.ApplyManualTrim();
+            Logger.Log($"✂️ Manual trim slot {_armedSlot.Value}: {(before ? "before" : "after")} t={runTime:F3}s → {run.DataPoints.Count} pts");
+            PlotAllRuns();
+        }
+
+        /// <summary>Clear any manual trim on the armed run and restore its full baseline.</summary>
+        public void ResetArmedRunTrim()
+        {
+            if (!_armedSlot.HasValue || !_runs.TryGetValue(_armedSlot.Value, out var run))
+                return;
+            if (run.IsRaceBox || run.BaselineDataPoints == null)
+                return;
+
+            run.TrimStartTime = null;
+            run.TrimEndTime = null;
+            run.ApplyManualTrim();
+            Logger.Log($"✂️ Manual trim reset slot {_armedSlot.Value} → {run.DataPoints.Count} pts");
+            PlotAllRuns();
         }
 
         public void AttachTuneToRun(int? slot)
@@ -790,6 +843,8 @@ namespace CastleOverlayV2
                     SourcePath = sourceArchivePath,
                     IsVisible = _plot.GetRunVisibility(plotSlot),
                     TimeShiftMs = run.TimeShiftMs,
+                    TrimStartTime = run.TrimStartTime,
+                    TrimEndTime = run.TrimEndTime,
                     TunePath = tuneArchivePath,
                     RadioSettings = run.Tune?.Radio
                 });

--- a/src/CastleOverlayV2/Models/ProjectManifest.cs
+++ b/src/CastleOverlayV2/Models/ProjectManifest.cs
@@ -20,6 +20,13 @@ namespace CastleOverlayV2.Models
         public string SourcePath { get; set; } = "";
         public bool IsVisible { get; set; } = true;
         public double TimeShiftMs { get; set; }
+
+        // Reversible manual-trim window in the run's own (re-zeroed) time, seconds.
+        // Null = no bound on that side. Optional/additive — older projects omit these and
+        // load untrimmed (MissingMemberHandling.Ignore).
+        public double? TrimStartTime { get; set; }
+        public double? TrimEndTime { get; set; }
+
         public string? TunePath { get; set; }
         public RadioTuneSettings? RadioSettings { get; set; }
     }

--- a/src/CastleOverlayV2/Models/RunData.cs
+++ b/src/CastleOverlayV2/Models/RunData.cs
@@ -1,4 +1,7 @@
 ﻿// File: src/CastleOverlayV2/Models/RunData.cs
+using System.Collections.Generic;
+using System.Linq;
+
 namespace CastleOverlayV2.Models
 {
     public class RunData
@@ -30,12 +33,54 @@ namespace CastleOverlayV2.Models
 
         public TuneSettings? Tune { get; set; }
 
+        // ── Reversible manual trim (Castle runs) ──────────────────────────────
+        // BaselineDataPoints holds the full post-load sample list (whatever auto-trim
+        // produced, or the full re-zeroed log when auto-trim was skipped). DataPoints is
+        // the displayed/working subset. Manual trim sets a time window over the baseline
+        // in the run's own (re-zeroed) time coordinate; null = no bound on that side.
+        // Reset clears the window and restores the baseline.
+        public List<DataPoint>? BaselineDataPoints { get; set; }
+        public double? TrimStartTime { get; set; }
+        public double? TrimEndTime { get; set; }
+
         public RunData()
         {
             DataPoints = new List<DataPoint>();
             Data = new Dictionary<string, List<DataPoint>>();
             IsRaceBox = false;
             TimeShiftMs = 0;
+        }
+
+        /// <summary>
+        /// Capture the current <see cref="DataPoints"/> as the immutable trim baseline,
+        /// if one hasn't been captured yet. Call once after load.
+        /// </summary>
+        public void CaptureTrimBaseline()
+        {
+            BaselineDataPoints ??= new List<DataPoint>(DataPoints);
+        }
+
+        /// <summary>
+        /// Recompute <see cref="DataPoints"/> from the baseline and the current trim window.
+        /// No-op for RaceBox runs or before a baseline exists. Inverted/empty windows that
+        /// would discard every sample are ignored (the request is treated as a no-op).
+        /// </summary>
+        public void ApplyManualTrim()
+        {
+            if (IsRaceBox || BaselineDataPoints == null)
+                return;
+
+            IEnumerable<DataPoint> kept = BaselineDataPoints;
+            if (TrimStartTime is double start)
+                kept = kept.Where(p => p.Time >= start);
+            if (TrimEndTime is double end)
+                kept = kept.Where(p => p.Time <= end);
+
+            var result = kept.ToList();
+            if (result.Count == 0)
+                return; // would empty the run — ignore the trim
+
+            DataPoints = result;
         }
     }
 }

--- a/src/CastleOverlayV2/Plot/PlotManager.cs
+++ b/src/CastleOverlayV2/Plot/PlotManager.cs
@@ -85,6 +85,20 @@ namespace CastleOverlayV2.Plot
         public event Action<Dictionary<string, double?[]>> CursorMoved;
         public event Action<double>? AlignmentDragged;
 
+        // Manual trim (right-click menu). The double payload is the clicked time in plot
+        // coordinates (seconds); the presenter converts it to the armed run's own time.
+        public event Action<double>? TrimBeforeRequested;
+        public event Action<double>? TrimAfterRequested;
+        public event Action? TrimResetRequested;
+
+        // Right-click trim menu + state. Enabled only while a Castle run is armed.
+        private ContextMenuStrip? _trimMenu;
+        private ToolStripMenuItem? _trimBeforeItem;
+        private ToolStripMenuItem? _trimAfterItem;
+        private ToolStripMenuItem? _trimResetItem;
+        private bool _manualTrimAvailable;
+        private double _lastRightClickPlotX;
+
         private bool _isFourPoleMode = false;
 
         // Voltage smoothing (Settings dialog).
@@ -223,7 +237,44 @@ namespace CastleOverlayV2.Plot
             _plot.MouseMove += FormsPlot_MouseMove;
             _plot.MouseDown += FormsPlot_MouseDown;
             _plot.MouseUp += FormsPlot_MouseUp;
+
+            BuildTrimMenu();
+
             _plot.Refresh();
+        }
+
+        /// <summary>
+        /// Build the right-click manual-trim menu and suppress ScottPlot's default
+        /// right-click menu so the two don't both pop. Items are enabled only while a
+        /// Castle run is armed (see <see cref="SetManualTrimAvailable"/>).
+        /// </summary>
+        private void BuildTrimMenu()
+        {
+            // Remove ScottPlot's built-in right-click menu entries so it shows nothing;
+            // we drive our own ContextMenuStrip from FormsPlot_MouseUp instead.
+            try { _plot.Menu?.Clear(); } catch { /* menu API absent — harmless */ }
+
+            _trimMenu = new ContextMenuStrip();
+            _trimBeforeItem = new ToolStripMenuItem("Remove data before here",
+                null, (_, _) => TrimBeforeRequested?.Invoke(_lastRightClickPlotX));
+            _trimAfterItem = new ToolStripMenuItem("Remove data after here",
+                null, (_, _) => TrimAfterRequested?.Invoke(_lastRightClickPlotX));
+            _trimResetItem = new ToolStripMenuItem("Reset trim",
+                null, (_, _) => TrimResetRequested?.Invoke());
+
+            _trimMenu.Items.Add(_trimBeforeItem);
+            _trimMenu.Items.Add(_trimAfterItem);
+            _trimMenu.Items.Add(new ToolStripSeparator());
+            _trimMenu.Items.Add(_trimResetItem);
+        }
+
+        /// <summary>
+        /// Enable/disable the right-click trim actions. Called by the presenter when a run
+        /// is armed (true only for Castle runs) or disarmed.
+        /// </summary>
+        public void SetManualTrimAvailable(bool available)
+        {
+            _manualTrimAvailable = available;
         }
 
         /// <summary>
@@ -1050,9 +1101,29 @@ namespace CastleOverlayV2.Plot
 
         private void FormsPlot_MouseUp(object? sender, MouseEventArgs e)
         {
+            if (e.Button == MouseButtons.Right)
+            {
+                ShowTrimMenu(e.Location);
+                return;
+            }
+
             if (!_alignmentDragging || e.Button != MouseButtons.Left) return;
             _alignmentDragging = false;
             _plot.Capture = false;
+        }
+
+        private void ShowTrimMenu(System.Drawing.Point location)
+        {
+            if (_trimMenu == null) return;
+
+            // Record the click time (plot X, seconds) for the trim actions to consume.
+            _lastRightClickPlotX = _plot.Plot.GetCoordinates(new Pixel(location.X, location.Y)).X;
+
+            if (_trimBeforeItem != null) _trimBeforeItem.Enabled = _manualTrimAvailable;
+            if (_trimAfterItem != null) _trimAfterItem.Enabled = _manualTrimAvailable;
+            if (_trimResetItem != null) _trimResetItem.Enabled = _manualTrimAvailable;
+
+            _trimMenu.Show(_plot, location);
         }
 
         // ---------------- Helpers ----------------

--- a/src/CastleOverlayV2/Services/CsvLoader.cs
+++ b/src/CastleOverlayV2/Services/CsvLoader.cs
@@ -253,13 +253,20 @@ namespace CastleOverlayV2.Services
                 Logger.Log($"🧪 Sample Acceleration values: {string.Join(", ", accelVals)}");
             }
 
+            // Snapshot the loaded samples as the reversible manual-trim baseline. Whatever
+            // auto-trim produced (windowed) or the full re-zeroed log (auto-trim skipped)
+            // becomes the set that right-click trim and "Reset trim" operate over.
+            runData.CaptureTrimBaseline();
+
             log?.WriteLine($"=== CsvLoader.Load() EXIT — Rows: {runData.DataPoints.Count} ===");
             log?.Close();
 
             Logger.Log($"CsvLoader.Load() exit — Rows: {runData.DataPoints.Count}");
 
             return noDragPass
-                ? LoadResult<RunData>.SuccessWithWarning(runData, "DragOverlay", "No drag pass detected in this log.\nAuto-trim was skipped.")
+                ? LoadResult<RunData>.SuccessWithWarning(runData, "DragOverlay",
+                    "No drag pass detected in this log.\nAuto-trim was skipped.\n\n" +
+                    "Arm the run and right-click the plot to trim it manually.")
                 : LoadResult<RunData>.Success(runData);
         }
 

--- a/src/CastleOverlayV2/Services/ProjectLoader.cs
+++ b/src/CastleOverlayV2/Services/ProjectLoader.cs
@@ -178,6 +178,18 @@ namespace CastleOverlayV2.Services
                     run.SourcePath = localPath;
                     run.TimeShiftMs = entry.TimeShiftMs;
 
+                    // Restore the reversible manual trim (Castle runs). The CsvLoader already
+                    // captured the baseline; re-apply the saved window over it. Re-parsing uses
+                    // the same trimForDrag, so the baseline matches what was saved.
+                    if (entry.SourceType == ProjectSourceType.Castle &&
+                        (entry.TrimStartTime.HasValue || entry.TrimEndTime.HasValue))
+                    {
+                        run.CaptureTrimBaseline();
+                        run.TrimStartTime = entry.TrimStartTime;
+                        run.TrimEndTime = entry.TrimEndTime;
+                        run.ApplyManualTrim();
+                    }
+
                     // Optional tune (Castle only). Missing tune = warning, not failure.
                     if (entry.SourceType == ProjectSourceType.Castle && !string.IsNullOrWhiteSpace(entry.TunePath))
                     {


### PR DESCRIPTION
## Summary

Adds a **right-click menu on the plot** to manually trim a Castle log when auto-trim fails to detect a drag pass. The user arms a run (existing alignment "arm" concept), then right-clicks the plot to **Remove data before here** / **Remove data after here**, with **Reset trim** to undo. The trim is reversible and persists in saved `.dragoverlay` projects.

Closes the gap described by the user: when `DragPassDetector` finds no pass, `CsvLoader` loads the full log with a "No drag pass detected" warning and there was previously no way to trim it down.

## Design decisions (confirmed with the user)
- **Target:** the armed/selected run (reuses the alignment arm concept).
- **Reversible:** the full loaded log is retained as a baseline; trim is a stored time window; **Reset trim** restores it.
- **Trim only:** no "set launch / t=0" — alignment stays in the arm+nudge system.

## Changes
- **`RunData`** — reversible-trim state (`BaselineDataPoints` + `TrimStartTime/EndTime`) with `CaptureTrimBaseline()` / `ApplyManualTrim()`. `DataPoints` remains the displayed subset, so `PlotManager`, stat cards and hover need no changes.
- **`CsvLoader`** — captures the post-load baseline; extends the "no drag pass" warning to mention manual trim.
- **`PlotManager`** — right-click `ContextMenuStrip`; suppresses ScottPlot's default menu via `Menu.Clear()`; `SetManualTrimAvailable` gates items to armed Castle runs; emits `TrimBefore/After/ResetRequested` events carrying the clicked plot-X.
- **`MainFormPresenter`** — `TrimArmedRun` / `ResetArmedRunTrim`, event wiring, and arm/disarm availability toggling. Converts plot-X → run time via the per-run offset.
- **Persistence** — `TrimStartTime/TrimEndTime` added to `ProjectRunEntry` (additive/optional), written in `BuildProjectSnapshot`, restored in `ProjectLoader`.

## Scope / out of scope
- **Castle runs only.** RaceBox uses `RunData.Data` channel-series (not `DataPoints`) and isn't auto-trimmed; menu items stay disabled for an armed RaceBox run.
- Setting the launch point (t=0) from the menu is intentionally deferred.

## Test / verify plan
- [x] `dotnet build` clean (0 errors); app launches without startup crash.
- [ ] Load a log where auto-trim fails ("No drag pass detected"); arm it; right-click left of the pass → **Remove data before here**; right-click right → **Remove data after here**; confirm the trace reframes and stat cards / time axis update.
- [ ] **Reset trim** restores the full log.
- [ ] A normal auto-trimmed log still loads windowed and can be further trimmed.
- [ ] Save `.dragoverlay`, reopen → trimmed window restored. Open an older project (no trim fields) → loads untrimmed, no error.
- [ ] Arm a RaceBox run → trim items disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)