### PR TITLE
Auto Load: one-button load of the most recent session (log + tune + RaceBox)

### DIFF
--- a/src/CastleOverlayV2/Controls/RunStrip.cs
+++ b/src/CastleOverlayV2/Controls/RunStrip.cs
@@ -32,6 +32,7 @@ namespace CastleOverlayV2.Controls
         public event Action<int>? DeleteRequested; // slot 1..6
         public event Action<int>? ArmRequested;    // slot 1..6 (click on chip body)
         public event Action? SettingsRequested;    // gear button
+        public event Action? AutoLoadRequested;    // auto-load button
 
         // ---- State ----------------------------------------------------------
         private readonly SlotChip[] _chips = new SlotChip[7]; // index 1..6
@@ -70,6 +71,29 @@ namespace CastleOverlayV2.Controls
             gear.Click += (_, _) => SettingsRequested?.Invoke();
             _toolTip.SetToolTip(gear, "Settings");
             Controls.Add(gear);
+
+            // Auto Load button — docks Right, added after the gear so it sits to its left.
+            var autoLoad = new Button
+            {
+                Text = "⤓ Auto",
+                Dock = DockStyle.Right,
+                Width = 72,
+                FlatStyle = FlatStyle.Flat,
+                BackColor = SurfaceCard,
+                ForeColor = TextAccent,
+                Margin = new Padding(0),
+                Padding = new Padding(0),
+                Font = new Font(SystemFonts.DefaultFont.FontFamily, 9f, FontStyle.Bold),
+                TabStop = false,
+                UseVisualStyleBackColor = false
+            };
+            autoLoad.FlatAppearance.BorderColor = BorderDef;
+            autoLoad.FlatAppearance.BorderSize = 1;
+            autoLoad.FlatAppearance.MouseOverBackColor = SurfaceBar;
+            autoLoad.FlatAppearance.MouseDownBackColor = SurfaceBar;
+            autoLoad.Click += (_, _) => AutoLoadRequested?.Invoke();
+            _toolTip.SetToolTip(autoLoad, "Load the most recent log + tune + RaceBox");
+            Controls.Add(autoLoad);
 
             _flow = new FlowLayoutPanel
             {

--- a/src/CastleOverlayV2/IMainView.cs
+++ b/src/CastleOverlayV2/IMainView.cs
@@ -13,6 +13,7 @@ namespace CastleOverlayV2
         string? PickTuneFile();
         string? PickProjectFileToOpen();
         string? PickProjectFileToSave();
+        string? PickFolder(string title, string? initialDir);
 
         // Dialogs
         void ShowError(string title, string message);

--- a/src/CastleOverlayV2/MainForm.cs
+++ b/src/CastleOverlayV2/MainForm.cs
@@ -109,6 +109,7 @@ namespace CastleOverlayV2
             _runStrip.DeleteRequested += slot => _presenter.DeleteRun(slot);
             _runStrip.ArmRequested += slot => _presenter.ToggleAlignmentArm(slot);
             _runStrip.SettingsRequested += ShowSettingsDialog;
+            _runStrip.AutoLoadRequested += () => _ = _presenter.AutoLoadAsync();
 
             _alignmentBar = new AlignmentBar();
             Controls.Add(_alignmentBar);
@@ -172,6 +173,15 @@ namespace CastleOverlayV2
 
         private static string ExistingDirOrEmpty(string? path) =>
             !string.IsNullOrWhiteSpace(path) && Directory.Exists(path) ? path : "";
+
+        public string? PickFolder(string title, string? initialDir)
+        {
+            using var dlg = new FolderBrowserDialog { Description = title, UseDescriptionForTitle = true };
+            string seed = ExistingDirOrEmpty(initialDir);
+            if (seed.Length > 0)
+                dlg.SelectedPath = seed;
+            return dlg.ShowDialog() == DialogResult.OK ? dlg.SelectedPath : null;
+        }
 
         public string? PickProjectFileToOpen()
         {

--- a/src/CastleOverlayV2/MainFormPresenter.cs
+++ b/src/CastleOverlayV2/MainFormPresenter.cs
@@ -105,6 +105,15 @@ namespace CastleOverlayV2
             string? path = _view.PickCastleCsvFile();
             if (path == null) return;
 
+            await LoadCastleRunFromPathAsync(slot, path);
+        }
+
+        /// <summary>
+        /// Load a Castle CSV at an explicit path into <paramref name="slot"/>, bypassing the
+        /// file dialog. Shared by the manual load button and Auto Load.
+        /// </summary>
+        private async Task LoadCastleRunFromPathAsync(int slot, string path)
+        {
             try
             {
                 var loader = new CsvLoader(_config);
@@ -161,11 +170,21 @@ namespace CastleOverlayV2
         // ============================================================
         public async Task LoadRaceBoxRunAsync(int uiSlot)
         {
-            int plotSlot = uiSlot + 3;
-            Logger.Log($"LoadRaceBoxRunAsync(UI {uiSlot} → plot slot {plotSlot}) started");
-
             string? path = _view.PickRaceBoxCsvFile();
             if (path == null) return;
+
+            await LoadRaceBoxRunFromPathAsync(uiSlot, path);
+        }
+
+        /// <summary>
+        /// Load a RaceBox CSV at an explicit path into RaceBox <paramref name="uiSlot"/> (plot
+        /// slot = uiSlot + 3), bypassing the file dialog. Shared by the manual load button and
+        /// Auto Load.
+        /// </summary>
+        private async Task LoadRaceBoxRunFromPathAsync(int uiSlot, string path)
+        {
+            int plotSlot = uiSlot + 3;
+            Logger.Log($"LoadRaceBoxRunAsync(UI {uiSlot} → plot slot {plotSlot}) started");
 
             try
             {
@@ -490,6 +509,112 @@ namespace CastleOverlayV2
                 Logger.Log($"Previewed tune without a loaded run: {Path.GetFileName(path)}");
                 _tunePanel.SetTune(null, result.Value);
             }
+        }
+
+        /// <summary>
+        /// Attach a Castle tune at an explicit path to the run in <paramref name="slot"/>,
+        /// bypassing the file dialog. Used by Auto Load. A parse failure is logged and skipped
+        /// (the run still loads without a tune) rather than aborting.
+        /// </summary>
+        private void AttachTuneFromPath(int slot, string path)
+        {
+            if (!_runs.TryGetValue(slot, out var run) || run.IsRaceBox)
+                return;
+
+            var result = new CastleTuneLoader().Load(path);
+            if (!result.Ok)
+            {
+                Logger.Log($"Auto Load: tune parse failed for {Path.GetFileName(path)}: {result.Message}");
+                return;
+            }
+
+            result.Value!.SourcePath = path;
+            var previousRadio = run.Tune?.Radio.Clone();
+            run.Tune = result.Value!;
+            if (previousRadio != null)
+                run.Tune.Radio = previousRadio;
+
+            _selectedTuneSlot = slot;
+            Logger.Log($"Auto Load: attached tune to Run {slot}: {Path.GetFileName(path)}");
+            RefreshTunePanelRuns();
+        }
+
+        /// <summary>
+        /// Load the most recent session in one click: the newest Castle log (Run 1), plus the
+        /// tune and RaceBox log whose save-times are nearest that log (attached / RaceBox 1).
+        /// Folders come from config; a blank/missing one prompts a folder picker that is then
+        /// remembered. Replaces whatever is currently loaded.
+        /// </summary>
+        public async Task AutoLoadAsync()
+        {
+            try
+            {
+                var cfg = _config.Config;
+                bool cfgChanged = false;
+
+                string? castleDir = EnsureFolder(cfg.CastleLogDirectory,
+                    "Select the Castle log folder", d => { cfg.CastleLogDirectory = d; cfgChanged = true; });
+                string? tuneDir = EnsureFolder(cfg.TuneDirectory,
+                    "Select the Castle tune folder", d => { cfg.TuneDirectory = d; cfgChanged = true; });
+                string? raceBoxDir = EnsureFolder(cfg.RaceBoxLogDirectory,
+                    "Select the RaceBox log folder", d => { cfg.RaceBoxLogDirectory = d; cfgChanged = true; });
+
+                if (cfgChanged)
+                    _config.Save();
+
+                var castle = AutoLoadResolver.Newest(castleDir, "*.csv");
+                DateTime? anchor = castle?.LastWriteTimeUtc
+                    ?? AutoLoadResolver.Newest(raceBoxDir, "*.csv")?.LastWriteTimeUtc;
+
+                if (anchor == null)
+                {
+                    _view.ShowInfo("Auto Load",
+                        "No Castle or RaceBox log files were found in the configured folders.");
+                    return;
+                }
+
+                var tune = castle == null ? null : AutoLoadResolver.Nearest(tuneDir, "*.dat", anchor.Value);
+                var raceBox = AutoLoadResolver.Nearest(raceBoxDir, "*.csv", anchor.Value);
+
+                // Replace everything so the button reliably shows the latest pass.
+                for (int s = 1; s <= 6; s++)
+                    DeleteRun(s);
+
+                if (castle != null)
+                {
+                    await LoadCastleRunFromPathAsync(1, castle.FullName);
+                    if (tune != null && _runs.ContainsKey(1))
+                        AttachTuneFromPath(1, tune.FullName);
+                }
+
+                if (raceBox != null)
+                    await LoadRaceBoxRunFromPathAsync(1, raceBox.FullName);
+
+                Logger.Log($"Auto Load: castle={castle?.Name ?? "—"} tune={tune?.Name ?? "—"} " +
+                           $"racebox={raceBox?.Name ?? "—"} anchor={anchor:u}");
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"ERROR in AutoLoad: {ex.Message}");
+                _view.ShowError("Auto Load", "An error occurred during Auto Load.\n\n" + ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Return an existing folder, or prompt the user to pick one (remembered via
+        /// <paramref name="onPicked"/>). Null if there's no usable folder.
+        /// </summary>
+        private string? EnsureFolder(string? current, string title, Action<string> onPicked)
+        {
+            if (!string.IsNullOrWhiteSpace(current) && Directory.Exists(current))
+                return current;
+
+            string? picked = _view.PickFolder(title, current);
+            if (string.IsNullOrWhiteSpace(picked) || !Directory.Exists(picked))
+                return null;
+
+            onPicked(picked);
+            return picked;
         }
 
         public void UpdateRadioSettings(int slot, RadioTuneSettings settings)

--- a/src/CastleOverlayV2/MainFormPresenter.cs
+++ b/src/CastleOverlayV2/MainFormPresenter.cs
@@ -573,8 +573,11 @@ namespace CastleOverlayV2
                     return;
                 }
 
-                var tune = castle == null ? null : AutoLoadResolver.Nearest(tuneDir, "*.dat", anchor.Value);
-                var raceBox = AutoLoadResolver.Nearest(raceBoxDir, "*.csv", anchor.Value);
+                // Only pair a tune / RaceBox log that was saved within 5 minutes of the Castle
+                // log — i.e. part of the same session, not a stray from another run.
+                var sessionWindow = TimeSpan.FromMinutes(5);
+                var tune = castle == null ? null : AutoLoadResolver.Nearest(tuneDir, "*.dat", anchor.Value, sessionWindow);
+                var raceBox = AutoLoadResolver.Nearest(raceBoxDir, "*.csv", anchor.Value, sessionWindow);
 
                 // Replace everything so the button reliably shows the latest pass.
                 for (int s = 1; s <= 6; s++)

--- a/src/CastleOverlayV2/Services/AutoLoadResolver.cs
+++ b/src/CastleOverlayV2/Services/AutoLoadResolver.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace CastleOverlayV2.Services
+{
+    /// <summary>
+    /// Resolves which file to pull from a log folder for the Auto Load feature.
+    /// UI-free and side-effect-free so it stays unit-testable (services must not call
+    /// MessageBox — see CLAUDE.md). All selection is by <see cref="FileInfo.LastWriteTimeUtc"/>.
+    /// </summary>
+    public static class AutoLoadResolver
+    {
+        /// <summary>
+        /// The newest file matching <paramref name="searchPattern"/> in <paramref name="folder"/>,
+        /// or null when the folder is missing/blank or contains no match.
+        /// </summary>
+        public static FileInfo? Newest(string? folder, string searchPattern)
+        {
+            return Enumerate(folder, searchPattern)
+                .OrderByDescending(f => f.LastWriteTimeUtc)
+                .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// The file matching <paramref name="searchPattern"/> whose write-time is closest to
+        /// <paramref name="anchorUtc"/> (ties broken toward the newer file), or null when the
+        /// folder is missing/blank or contains no match. Used to group the tune + RaceBox logs
+        /// saved around the same time as the anchoring Castle log.
+        /// </summary>
+        public static FileInfo? Nearest(string? folder, string searchPattern, DateTime anchorUtc)
+        {
+            return Enumerate(folder, searchPattern)
+                .OrderBy(f => Math.Abs((f.LastWriteTimeUtc - anchorUtc).Ticks))
+                .ThenByDescending(f => f.LastWriteTimeUtc)
+                .FirstOrDefault();
+        }
+
+        private static IEnumerable<FileInfo> Enumerate(string? folder, string searchPattern)
+        {
+            if (string.IsNullOrWhiteSpace(folder) || !Directory.Exists(folder))
+                return Enumerable.Empty<FileInfo>();
+
+            try
+            {
+                return new DirectoryInfo(folder)
+                    .EnumerateFiles(searchPattern, SearchOption.TopDirectoryOnly)
+                    .ToList();
+            }
+            catch (Exception)
+            {
+                // Unreadable folder (permissions, transient IO) — treat as no match.
+                return Enumerable.Empty<FileInfo>();
+            }
+        }
+    }
+}

--- a/src/CastleOverlayV2/Services/AutoLoadResolver.cs
+++ b/src/CastleOverlayV2/Services/AutoLoadResolver.cs
@@ -28,13 +28,23 @@ namespace CastleOverlayV2.Services
         /// <paramref name="anchorUtc"/> (ties broken toward the newer file), or null when the
         /// folder is missing/blank or contains no match. Used to group the tune + RaceBox logs
         /// saved around the same time as the anchoring Castle log.
+        /// <para>
+        /// When <paramref name="within"/> is set, a match is only returned if it is within that
+        /// window of the anchor — so a stray file from a different session isn't pulled in.
+        /// </para>
         /// </summary>
-        public static FileInfo? Nearest(string? folder, string searchPattern, DateTime anchorUtc)
+        public static FileInfo? Nearest(string? folder, string searchPattern, DateTime anchorUtc, TimeSpan? within = null)
         {
-            return Enumerate(folder, searchPattern)
+            var best = Enumerate(folder, searchPattern)
                 .OrderBy(f => Math.Abs((f.LastWriteTimeUtc - anchorUtc).Ticks))
                 .ThenByDescending(f => f.LastWriteTimeUtc)
                 .FirstOrDefault();
+
+            if (best != null && within is TimeSpan window &&
+                (best.LastWriteTimeUtc - anchorUtc).Duration() > window)
+                return null;
+
+            return best;
         }
 
         private static IEnumerable<FileInfo> Enumerate(string? folder, string searchPattern)


### PR DESCRIPTION
## Summary

Adds an **Auto Load** button to the run strip that loads the latest drag pass in one click — no browsing. A pass drops three files saved around the same time, each in its own folder: a Castle ESC log (`.csv`), a Castle tune (`.dat`), and a RaceBox GPS log (`.csv`). Auto Load grabs the newest Castle log as the anchor and matches the tune + RaceBox files by **nearest save-time**, so the three from the same session are grouped even when a folder holds older/newer strays.

This is the pragmatic first step toward issue #42 (auto-import) without needing to read telemetry directly off the ESC.

## Behaviour
- **Anchor:** newest Castle log (max `LastWriteTimeUtc`) → **Run 1**.
- **Matched by time:** tune nearest the anchor → attached to Run 1; RaceBox nearest the anchor → **RaceBox 1**.
- **Fallback:** no Castle log → anchor on newest RaceBox and load just that (no tune).
- **Replace mode:** clears all slots first, so the button reliably shows the latest pass.
- **Folders** come from Settings config (Castle log / tune / RaceBox). A blank or missing folder opens a picker and the choice is **remembered** in config; cancel skips that source. No Castle and no RaceBox file found → info message.

## Changes
- **`Services/AutoLoadResolver.cs`** (new) — UI-free `Newest()` / `Nearest()` by `LastWriteTimeUtc`; null-safe on missing/empty/unreadable folders.
- **`MainFormPresenter`** — extracted path-based cores `LoadCastleRunFromPathAsync` / `LoadRaceBoxRunFromPathAsync` / `AttachTuneFromPath` from the existing dialog-driven methods (callers unchanged); new `AutoLoadAsync` orchestration + `EnsureFolder` helper.
- **`IMainView` / `MainForm`** — `PickFolder(title, initialDir)` via `FolderBrowserDialog`.
- **`Controls/RunStrip`** — "⤓ Auto" button beside the gear + `AutoLoadRequested` event; wired in `MainForm`.

Reuses `CsvLoader`, `RaceBoxLoader`, `CastleTuneLoader`, `DeleteRun`, and the existing config directories.

## Test / verify plan
- [x] `dotnet build` clean (0 errors); app launches without startup crash.
- [ ] Set the three folders in Settings to a matching session. Click **Auto Load** → newest Castle in Run 1, its nearest-time tune attached (visible in Tune panel), nearest RaceBox in RaceBox 1; chart + stats populate.
- [ ] Drop a newer Castle/tune/RaceBox trio → Auto Load replaces with the newer set.
- [ ] Leave a folder blank → picker appears, choice saved (reopen Settings to confirm); second Auto Load doesn't re-prompt.
- [ ] Empty/strays-only folders → info message, no crash; missing tune/RaceBox → loads what exists.
- [ ] Per-slot manual load buttons and manual Attach Tune still work (refactor regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)