### PR TITLE
chore: prepare v1.16 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,5 +77,6 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: DragOverlay v${{ steps.ver.outputs.version }}
           files: installer-out/DragOverlay-Setup-v${{ steps.ver.outputs.version }}.exe
+          body_path: Docs/RELEASE_NOTES.md
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/Docs/RELEASE_NOTES.md
+++ b/Docs/RELEASE_NOTES.md
@@ -1,0 +1,33 @@
+# DragOverlay v1.16
+
+Thanks for using DragOverlay! This update adds two big time-savers for getting your runs on screen.
+
+## What's new
+
+### ⚡ Auto Load — your latest run in one click
+A new **Auto** button (next to the settings gear) loads your most recent pass automatically:
+
+- Pulls in the **newest Castle ESC log**, its **matching tune**, and the **matching RaceBox GPS log**.
+- Automatically pairs the three files from the *same* pass — it matches them by save time (within 5 minutes of each other), so it won't grab a file from a different run.
+- The first time you use it, DragOverlay asks where your log folders are, then remembers them for next time.
+
+No more browsing for files after every pass — plug in, save your logs, click **Auto**.
+
+### ✂️ Manual log trimming
+When the automatic trim doesn't line up with your launch, you can now trim a log by hand:
+
+- Select a run, then **right-click the chart** and choose **"Remove data before here"** or **"Remove data after here"**.
+- Changed your mind? **"Reset trim"** restores the full log.
+- Your trims are remembered when you save a `.dragoverlay` project.
+
+## How to install
+
+1. Download **`DragOverlay-Setup-v1.16.exe`** from the **Assets** below.
+2. Run it and follow the prompts.
+3. Launch **DragOverlay** from the Start menu.
+
+> Works on Windows 10 and 11. If Windows SmartScreen shows an "unrecognized app" warning, click **More info → Run anyway**.
+
+## Need the log folders set up?
+
+Open **Settings** (the gear button) and point DragOverlay at your Castle log, tune, and RaceBox folders. Auto Load uses these — and it'll prompt you the first time if they're not set.

--- a/Tests/CastleOverlayV2.Tests/FakeMainView.cs
+++ b/Tests/CastleOverlayV2.Tests/FakeMainView.cs
@@ -12,6 +12,7 @@ public sealed class FakeMainView : IMainView
     public string? TuneFileToReturn { get; set; }
     public string? ProjectOpenPathToReturn { get; set; }
     public string? ProjectSavePathToReturn { get; set; }
+    public string? FolderToReturn { get; set; }
 
     public readonly List<(string title, string message)> Errors = new();
     public readonly List<(string title, string message)> Infos = new();
@@ -33,6 +34,12 @@ public sealed class FakeMainView : IMainView
     public int SettingsShown;
     public string? PickProjectFileToOpen() => ProjectOpenPathToReturn;
     public string? PickProjectFileToSave() => ProjectSavePathToReturn;
+    public readonly List<(string title, string? initialDir)> FolderPicks = new();
+    public string? PickFolder(string title, string? initialDir)
+    {
+        FolderPicks.Add((title, initialDir));
+        return FolderToReturn;
+    }
 
     public void ShowError(string title, string message) => Errors.Add((title, message));
     public void ShowInfo(string title, string message) => Infos.Add((title, message));

--- a/installer/installer.iss
+++ b/installer/installer.iss
@@ -10,7 +10,7 @@
 #define MyAppExeName  "CastleOverlayV2.exe"
 
 #ifndef MyAppVersion
-  #define MyAppVersion "1.15"
+  #define MyAppVersion "1.16"
 #endif
 
 #ifndef MyPublishDir

--- a/src/CastleOverlayV2/Models/Config.cs
+++ b/src/CastleOverlayV2/Models/Config.cs
@@ -15,7 +15,7 @@ namespace CastleOverlayV2.Models
 
         public bool EnableDebugLogging { get; set; } = false;
 
-        public string BuildNumber { get; set; } = "1.15";
+        public string BuildNumber { get; set; } = "1.16";
 
         // ---- Default open folders (Settings dialog) -----------------------
         public string CastleLogDirectory { get; set; } = "";


### PR DESCRIPTION
## Summary
Prepares the **v1.16** release covering this round's two user-facing features:
- Manual log trimming ([#108](https://github.com/stewmac570/DragOverlay/pull/108))
- Auto Load ([#109](https://github.com/stewmac570/DragOverlay/pull/109))

## Changes
- Bump `MyAppVersion` (`installer/installer.iss`) and `Config.BuildNumber` to **1.16**.
- Add **`Docs/RELEASE_NOTES.md`** — user-facing notes — and wire it into the release workflow (`body_path`) so it becomes the GitHub Release description (auto changelog appended below).
- **Fix `FakeMainView`** to implement the new `IMainView.PickFolder` member added in #109. That addition had broken the test project build on `main`; the release CI runs `dotnet test`, so this is required for the release to publish.

## After merge
Push tag `v1.16` on `main` → the Release workflow builds the installer and publishes **DragOverlay v1.16** with `DragOverlay-Setup-v1.16.exe` attached and the user-facing notes as the description.

## Verify
- [x] `dotnet build -c Release` clean (0 errors)
- [x] `dotnet test` — 54/54 passing (FakeMainView fix confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)